### PR TITLE
feat: add installation check banner on AI generation pages

### DIFF
--- a/src/components/NoInstallationBanner.tsx
+++ b/src/components/NoInstallationBanner.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom'
+
+export default function NoInstallationBanner() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="mb-6 p-4 rounded-xl bg-amber-50 border border-amber-300 text-amber-800">
+      <p className="font-semibold mb-1">Instalacion local no detectada</p>
+      <p className="text-sm mb-3">
+        Para generar contenido con IA necesitas tener una instalacion local vinculada a tu cuenta.
+        Esta ejecuta el modelo de lenguaje en tu maquina.
+      </p>
+      <button
+        type="button"
+        onClick={() => navigate('/settings/installation')}
+        className="text-sm font-bold text-amber-700 underline hover:text-amber-900"
+      >
+        Configurar instalacion
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/useInstallation.ts
+++ b/src/hooks/useInstallation.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import { getMyInstallation } from '../services/api'
+import type { Installation } from '../services/api'
+
+export function useInstallation() {
+  const [installation, setInstallation] = useState<Installation | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [checked, setChecked] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    getMyInstallation()
+      .then((inst) => {
+        if (!cancelled) setInstallation(inst)
+      })
+      .catch(() => {
+        if (!cancelled) setInstallation(null)
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+          setChecked(true)
+        }
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  return {
+    installation,
+    hasInstallation: installation !== null,
+    loading,
+    checked,
+  }
+}

--- a/src/pages/characters/CreateCharacterPage.tsx
+++ b/src/pages/characters/CreateCharacterPage.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { createCharacter, generateCharacter } from '../../services/api'
 import type { Character } from '../../services/api'
+import { useInstallation } from '../../hooks/useInstallation'
+import NoInstallationBanner from '../../components/NoInstallationBanner'
 
 export default function CreateCharacterPage() {
   const { id: worldId } = useParams()
@@ -23,6 +25,7 @@ export default function CreateCharacterPage() {
   // Common
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  const { hasInstallation, checked: installationChecked } = useInstallation()
 
   const handleGoalChange = (idx: number, value: string) => {
     setGoals(goals.map((g, i) => (i === idx ? value : g)))
@@ -139,6 +142,7 @@ export default function CreateCharacterPage() {
 
         {mode === 'ai' && (
           <div>
+            {installationChecked && !hasInstallation && <NoInstallationBanner />}
             <form onSubmit={handleAIGenerate}>
               <div className="mb-6">
                 <label className="block text-gray-700 mb-1 font-medium">Describe el personaje que quieres crear</label>

--- a/src/pages/home/CreateWorldPage.tsx
+++ b/src/pages/home/CreateWorldPage.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { createWorld, generateWorld } from '../../services/api'
 import type { World } from '../../services/api'
+import { useInstallation } from '../../hooks/useInstallation'
+import NoInstallationBanner from '../../components/NoInstallationBanner'
 
 export default function CreateWorldPage() {
   const [mode, setMode] = useState<'manual' | 'ai'>('manual')
@@ -20,6 +22,7 @@ export default function CreateWorldPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const navigate = useNavigate()
+  const { hasInstallation, checked: installationChecked } = useInstallation()
 
   const handleFactionChange = (idx: number, value: string) => {
     setFactions(factions.map((f, i) => (i === idx ? value : f)))
@@ -132,6 +135,7 @@ export default function CreateWorldPage() {
         )}
         {mode === 'ai' && (
           <div>
+            {installationChecked && !hasInstallation && <NoInstallationBanner />}
             <form onSubmit={handleAIGenerate}>
               <div className="mb-6">
                 <label className="block text-gray-700 mb-1 font-medium">Describe el mundo que quieres crear</label>

--- a/src/pages/scenes/CreateScenePage.tsx
+++ b/src/pages/scenes/CreateScenePage.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { createScene, generateScene } from '../../services/api'
 import type { Scene } from '../../services/api'
+import { useInstallation } from '../../hooks/useInstallation'
+import NoInstallationBanner from '../../components/NoInstallationBanner'
 
 export default function CreateScenePage() {
   const { id: worldId } = useParams()
@@ -23,6 +25,7 @@ export default function CreateScenePage() {
   // Common
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  const { hasInstallation, checked: installationChecked } = useInstallation()
 
   const handleManualSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -123,6 +126,7 @@ export default function CreateScenePage() {
 
         {mode === 'ai' && (
           <div>
+            {installationChecked && !hasInstallation && <NoInstallationBanner />}
             <form onSubmit={handleAIGenerate}>
               <div className="mb-6">
                 <label className="block text-gray-700 mb-1 font-medium">Describe la escena que quieres crear</label>

--- a/src/pages/scenes/SceneDetailPage.tsx
+++ b/src/pages/scenes/SceneDetailPage.tsx
@@ -9,6 +9,8 @@ import {
   getWorldDetail,
 } from '../../services/api'
 import type { SceneDetail, Character, Event as StoryEvent } from '../../services/api'
+import { useInstallation } from '../../hooks/useInstallation'
+import NoInstallationBanner from '../../components/NoInstallationBanner'
 
 export default function SceneDetailPage() {
   const { worldId, sceneId } = useParams()
@@ -31,6 +33,8 @@ export default function SceneDetailPage() {
   // Narrative
   const [narrative, setNarrative] = useState<string | null>(null)
   const [generatingNarrative, setGeneratingNarrative] = useState(false)
+
+  const { hasInstallation, checked: installationChecked } = useInstallation()
 
   useEffect(() => {
     if (!sceneId || !worldId) return
@@ -208,6 +212,7 @@ export default function SceneDetailPage() {
         )}
 
         {/* Generate Events Form */}
+        {installationChecked && !hasInstallation && <NoInstallationBanner />}
         <form onSubmit={handleGenerateEvents} className="p-4 bg-gray-50 rounded-lg border">
           <h4 className="font-semibold text-gray-700 mb-3">Generar eventos con IA</h4>
           <div className="mb-3">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -220,6 +220,25 @@ export function getSceneNarrative(sceneId: number) {
 
 // --- Installation ---
 
+export interface Installation {
+  id: number
+  user_id: number
+  machine_name: string
+  os: string
+  arch: string
+  version: string
+  ip: string
+  port: number
+  status: string
+  last_seen_at: string
+  created_at: string
+  channel_id: string
+}
+
+export function getMyInstallation() {
+  return request<Installation>('/installation/me')
+}
+
 export function getLinkingToken() {
   return request<{ token: string }>('/installation/linking-token')
 }


### PR DESCRIPTION
- Add useInstallation hook using /installation/me endpoint
- Add NoInstallationBanner warning component
- Show banner on CreateWorld, CreateCharacter, CreateScene, SceneDetail
- Replace getInstallationStatus with getMyInstallation in api.ts
- Add Installation type definition