### PR TITLE
feat: show installation details when linked

### DIFF
--- a/plans/installation-details-page.md
+++ b/plans/installation-details-page.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Installation Details Page
+
+**Created:** 2026-03-01
+**Status:** Draft
+**Estimated Effort:** XS
+
+## Summary
+
+Transform the existing `InstallationPage` from a pure onboarding wizard into a two-state page:
+- **Has installation**: Show installation details (machine name, OS, arch, status, last seen, IP, port, version, channel ID) in a detail card, followed by the existing token generator for re-linking.
+- **No installation**: Show the current onboarding wizard as-is (instructions + token generator).
+
+No backend changes needed — `GET /installation/me` already returns all fields. No new dependencies.
+
+## Research Findings
+
+### Repository Patterns
+- Detail pages use `max-w-4xl mx-auto space-y-8 mt-8` outer wrapper with stacked white cards (`bg-white/90 shadow-2xl rounded-2xl p-8 border border-gray-200`)
+- Loading/error guards at the top: `if (loading) return <div>...</div>`
+- `useInstallation` hook already fetches from `/installation/me` and returns `{ installation, hasInstallation, loading, checked }`
+- Status badges use colored pills: `bg-green-100 text-green-700`, `bg-yellow-100 text-yellow-700`, etc.
+
+### Available Data (from `Installation` interface in api.ts)
+- `machine_name` — Machine hostname
+- `os` — Operating system
+- `arch` — CPU architecture
+- `version` — Generator version
+- `ip` — IP address
+- `port` — Port number
+- `status` — e.g. "online"/"offline"
+- `last_seen_at` — ISO timestamp
+- `created_at` — ISO timestamp
+- `channel_id` — RabbitMQ channel
+
+### Gaps Identified
+None — all data is already available from the API.
+
+## Questions to Resolve
+
+None — straightforward feature.
+
+## Implementation Order (TDD)
+
+### Step 1: Refactor InstallationPage to show installation details
+- **Implement:** `src/pages/settings/InstallationPage.tsx`
+  - Import and use `useInstallation` hook
+  - Add loading guard at top
+  - When `hasInstallation`: render a detail card with all installation fields, status badge (green for online, amber for offline), formatted dates, and channel ID in monospace
+  - When `!hasInstallation`: render the existing onboarding wizard (unchanged)
+  - Keep the token generator section available in both states (collapsed/secondary when installation exists)
+- **Validation:** `npm run build` passes, `npm run lint` clean
+
+### Final: Cleanup
+- [ ] Verify lint clean
+- [ ] Verify build passes
+- **Validation:** `npm run lint && npm run build`
+
+## Acceptance Criteria
+
+- [ ] When user has a linked installation, the page shows all installation details
+- [ ] Status is shown as a colored badge (green=online, amber=offline)
+- [ ] Dates (`last_seen_at`, `created_at`) are formatted in human-readable locale format
+- [ ] When user has no installation, the page shows the setup instructions (current behavior)
+- [ ] Token generation still works in both states
+- [ ] Lint and build pass
+
+## Security Considerations
+
+None — read-only display of existing data from an authenticated endpoint.
+
+## Performance Considerations
+
+None — single API call already made by the existing hook.
+
+## Related Files
+
+- `src/pages/settings/InstallationPage.tsx` (main change)
+- `src/hooks/useInstallation.ts` (reuse, no changes)
+- `src/services/api.ts` (reuse `Installation` type and `getMyInstallation`, no changes)
+
+---
+
+## Next Steps
+
+When ready to implement, run:
+- `/wiz:work plans/installation-details-page.md` - Execute the plan

--- a/src/pages/settings/InstallationPage.tsx
+++ b/src/pages/settings/InstallationPage.tsx
@@ -1,7 +1,33 @@
 import { useState } from 'react'
 import { getLinkingToken } from '../../services/api'
+import { useInstallation } from '../../hooks/useInstallation'
 
-export default function InstallationPage() {
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleString()
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const isOnline = status.toLowerCase() === 'online'
+  const bg = isOnline ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+  return (
+    <span className={`${bg} px-3 py-1 rounded-full text-sm font-semibold`}>
+      {status}
+    </span>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between py-2 border-b border-gray-100 last:border-b-0">
+      <span className="text-gray-500 font-medium">{label}</span>
+      <span className="text-gray-800">{value}</span>
+    </div>
+  )
+}
+
+function TokenGenerator() {
   const [token, setToken] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -28,47 +54,108 @@ export default function InstallationPage() {
   }
 
   return (
+    <div>
+      <button
+        onClick={handleGenerate}
+        disabled={loading}
+        className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-6 rounded-lg shadow-lg transition-all duration-200 text-lg w-full disabled:opacity-60"
+      >
+        {loading ? 'Generando...' : 'Generar token de vinculacion'}
+      </button>
+
+      {error && <p className="mt-4 text-red-600 text-sm text-center font-semibold">{error}</p>}
+
+      {token && (
+        <div className="mt-6 p-4 bg-gray-50 rounded-lg border">
+          <div className="flex justify-between items-center mb-2">
+            <span className="font-semibold text-gray-700">Token de vinculacion:</span>
+            <button
+              onClick={handleCopy}
+              className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm font-semibold"
+            >
+              {copied ? 'Copiado!' : 'Copiar'}
+            </button>
+          </div>
+          <div className="bg-gray-900 text-green-400 p-3 rounded font-mono text-xs break-all overflow-auto max-h-32">
+            {token}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SetupInstructions() {
+  return (
+    <div className="mb-6 text-gray-700 space-y-3">
+      <p>Para generar contenido con IA necesitas un generador local ejecutandose en tu maquina.</p>
+      <ol className="list-decimal list-inside space-y-2 ml-2">
+        <li>Genera un <strong>token de vinculacion</strong> con el boton de abajo</li>
+        <li>Usa el token para registrar tu instalacion local (endpoint <code className="bg-gray-100 px-1 rounded">POST /installation</code>)</li>
+        <li>Copia el <code className="bg-gray-100 px-1 rounded">channelID</code> de la respuesta</li>
+        <li>Configura tu generador con <code className="bg-gray-100 px-1 rounded">CHANNEL_ID=&lt;channelID&gt;</code> en el archivo <code className="bg-gray-100 px-1 rounded">.env</code></li>
+        <li>Inicia el generador: <code className="bg-gray-100 px-1 rounded">npm run start</code></li>
+      </ol>
+    </div>
+  )
+}
+
+export default function InstallationPage() {
+  const { installation, hasInstallation, loading } = useInstallation()
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-96 text-lg text-gray-500">
+        Cargando instalacion...
+      </div>
+    )
+  }
+
+  if (hasInstallation && installation) {
+    return (
+      <div className="max-w-2xl mx-auto mt-8 space-y-6">
+        <div className="bg-white/90 shadow-2xl rounded-2xl p-8 border border-gray-200">
+          <div className="flex justify-between items-center mb-6">
+            <h2 className="text-3xl font-extrabold text-purple-800">Instalacion local</h2>
+            <StatusBadge status={installation.status} />
+          </div>
+
+          <div className="space-y-0">
+            <DetailRow label="Maquina" value={installation.machine_name} />
+            <DetailRow label="Sistema operativo" value={installation.os} />
+            <DetailRow label="Arquitectura" value={installation.arch} />
+            <DetailRow label="Version" value={installation.version} />
+            <DetailRow label="IP" value={installation.ip} />
+            <DetailRow label="Puerto" value={String(installation.port)} />
+            <DetailRow label="Ultima conexion" value={formatDate(installation.last_seen_at)} />
+            <DetailRow label="Vinculada desde" value={formatDate(installation.created_at)} />
+          </div>
+
+          <div className="mt-6 p-3 bg-gray-50 rounded-lg border">
+            <span className="text-gray-500 text-sm font-medium">Channel ID</span>
+            <div className="font-mono text-xs text-gray-700 break-all mt-1">
+              {installation.channel_id}
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-white/90 shadow-xl rounded-2xl p-8 border border-gray-200">
+          <h3 className="text-xl font-bold text-purple-700 mb-4">Revincular instalacion</h3>
+          <p className="text-gray-600 text-sm mb-4">
+            Si necesitas vincular una nueva instalacion, genera un nuevo token.
+          </p>
+          <TokenGenerator />
+        </div>
+      </div>
+    )
+  }
+
+  return (
     <div className="max-w-2xl mx-auto mt-8">
       <div className="bg-white/90 shadow-2xl rounded-2xl p-8 border border-gray-200">
         <h2 className="text-3xl font-extrabold text-purple-800 mb-6">Configurar generador local</h2>
-
-        <div className="mb-6 text-gray-700 space-y-3">
-          <p>Para generar contenido con IA necesitas un generador local ejecutándose en tu máquina.</p>
-          <ol className="list-decimal list-inside space-y-2 ml-2">
-            <li>Genera un <strong>token de vinculación</strong> con el botón de abajo</li>
-            <li>Usa el token para registrar tu instalación local (endpoint <code className="bg-gray-100 px-1 rounded">POST /installation</code>)</li>
-            <li>Copia el <code className="bg-gray-100 px-1 rounded">channelID</code> de la respuesta</li>
-            <li>Configura tu generador con <code className="bg-gray-100 px-1 rounded">CHANNEL_ID=&lt;channelID&gt;</code> en el archivo <code className="bg-gray-100 px-1 rounded">.env</code></li>
-            <li>Inicia el generador: <code className="bg-gray-100 px-1 rounded">npm run start</code></li>
-          </ol>
-        </div>
-
-        <button
-          onClick={handleGenerate}
-          disabled={loading}
-          className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-6 rounded-lg shadow-lg transition-all duration-200 text-lg w-full disabled:opacity-60"
-        >
-          {loading ? 'Generando...' : 'Generar token de vinculación'}
-        </button>
-
-        {error && <p className="mt-4 text-red-600 text-sm text-center font-semibold">{error}</p>}
-
-        {token && (
-          <div className="mt-6 p-4 bg-gray-50 rounded-lg border">
-            <div className="flex justify-between items-center mb-2">
-              <span className="font-semibold text-gray-700">Token de vinculación:</span>
-              <button
-                onClick={handleCopy}
-                className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-sm font-semibold"
-              >
-                {copied ? 'Copiado!' : 'Copiar'}
-              </button>
-            </div>
-            <div className="bg-gray-900 text-green-400 p-3 rounded font-mono text-xs break-all overflow-auto max-h-32">
-              {token}
-            </div>
-          </div>
-        )}
+        <SetupInstructions />
+        <TokenGenerator />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Refactor `InstallationPage` to show installation details when user has a linked installation
- Display machine name, OS, architecture, version, IP:port, status badge (green/amber), last seen, created at, and channel ID
- Keep setup instructions + token generator for users without an installation
- Add re-link section for existing installations

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] Page shows loading state while fetching
- [x] Page shows detail card when installation exists
- [x] Page shows setup wizard when no installation
- [x] Token generation works in both states