### PR TITLE
feat(character-graph): edges + warmth (Fase 0 + Fase 1)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-character-graph-edges-warmth.md
+++ b/docs/superpowers/plans/2026-04-16-character-graph-edges-warmth.md
@@ -1,0 +1,1458 @@
+# Character Graph — Edges + Warmth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade the character psychology graph canvas (`CharacterGraphCanvas.tsx`) with floating edges, literary flow labels with animated particles, an official MiniMap, per-domain glyphs, a layered paper background, and a fistful of Fase 0 cleanup fixes (collision scoping, drag persistence, drawer-aware `fitView`, outline rename, a11y).
+
+**Architecture:** All work is inside `src/components/character-graph/*`. Two new custom edge types live under `src/components/character-graph/edges/` with a shared geometry helper. The existing `GraphMinimap` is renamed (it's actually a decision flow outline). No backend, no data model, no routing changes.
+
+**Tech Stack:** React 19, TypeScript, `@xyflow/react@12.10.1`, Tailwind 4, `framer-motion` (for `useReducedMotion`), `lucide-react`. No test framework is configured — verification is via `npm run lint`, `npm run build`, and specific manual browser checks per task.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-character-graph-edges-warmth-design.md` (commit `c9bd9d4`).
+
+**Convention — canvas position persistence:** `canvas_x=0 && canvas_y=0` means "never persisted, compute from layout". Any non-zero pair means "user-placed, respect it". This mirrors `LocationGraphCanvas.tsx:82`.
+
+**Convention — verification instead of TDD:** No test runner exists. Each task ends with (a) `npm run lint`, (b) in some cases `npm run build`, (c) a specific browser action + observable. Do not skip the browser check: the only way a CSS or positional regression surfaces is visually.
+
+---
+
+## File structure
+
+### New files
+
+- `src/components/character-graph/edges/getEdgeParams.ts` — geometry helper shared by all floating-style edges (v12 `useInternalNode` based).
+- `src/components/character-graph/edges/FloatingEdge.tsx` — custom edge: bezier path anchored at intersections with source/target node rects. Used by orbital ↔ container edges.
+- `src/components/character-graph/edges/LiteraryFlowEdge.tsx` — custom edge: smoothstep path + `EdgeLabelRenderer` label in real Lora + SVG ink-pool dot + optional `animateMotion` particle. Used by the 4 domain-chain edges.
+- `src/components/character-graph/edges/index.ts` — barrel export so `CharacterGraphCanvas` imports from a single place.
+
+### Renamed files
+
+- `src/components/character-graph/GraphMinimap.tsx` → `src/components/character-graph/DecisionFlowOutline.tsx` (export `DecisionFlowOutline`). Use `git mv` so rename is preserved in history.
+
+### Modified files
+
+- `src/components/character-graph/CharacterGraphCanvas.tsx` — register `edgeTypes`, wrap in `ReactFlowProvider`, new props (`drawerOpen`, `onPersistPosition`), `resolveCollisions` scoped to orbitals, a11y on custom nodes, `<MiniMap />`, double `<Background />`, prefer persisted orbital positions, per-domain `lucide-react` icon, background tint.
+- `src/components/character-graph/CharacterGraphPage.tsx` — pass `drawerOpen` and `onPersistPosition`, update rename import.
+- `src/components/character-graph/useCharacterGraph.ts` — no changes (pre-existing `moveNode` already persists).
+
+---
+
+## Phase 0 — Trivial wins
+
+### Task 0.1: Scope `resolveCollisions` to orbital nodes only
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx:327-369`
+
+- [ ] **Step 1: Replace `resolveCollisions`**
+
+Replace the body of `resolveCollisions` (lines 327-369) so containers, entry, and exit nodes are excluded from the collision pass. Only `type === 'child'` nodes are pushed around.
+
+Target state of the function:
+
+```ts
+function resolveCollisions(nodes: Node[]): Node[] {
+  type Box = { id: string; x: number; y: number; w: number; h: number }
+
+  // Only orbital child nodes participate in collision resolution.
+  // Containers (type 'container') and entry/exit pills stay anchored.
+  const movable = nodes.filter(n => n.type === 'child')
+
+  const boxes: Box[] = movable.map(n => ({
+    id: n.id,
+    x: n.position.x,
+    y: n.position.y,
+    w: (n.measured?.width  ?? 60) + MARGIN,
+    h: (n.measured?.height ?? 60) + MARGIN,
+  }))
+
+  const MAX_ITER = 20
+  for (let iter = 0; iter < MAX_ITER; iter++) {
+    let moved = false
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        const a = boxes[i], b = boxes[j]
+        const ax = a.x + a.w / 2, ay = a.y + a.h / 2
+        const bx = b.x + b.w / 2, by = b.y + b.h / 2
+        const dx = bx - ax, dy = by - ay
+        const overlapX = (a.w + b.w) / 2 - Math.abs(dx)
+        const overlapY = (a.h + b.h) / 2 - Math.abs(dy)
+        if (overlapX > 0 && overlapY > 0) {
+          moved = true
+          if (overlapX < overlapY) {
+            const push = overlapX / 2 * (dx > 0 ? 1 : -1)
+            a.x -= push; b.x += push
+          } else {
+            const push = overlapY / 2 * (dy > 0 ? 1 : -1)
+            a.y -= push; b.y += push
+          }
+        }
+      }
+    }
+    if (!moved) break
+  }
+
+  const boxById = new Map(boxes.map(b => [b.id, b]))
+  return nodes.map(n => {
+    const box = boxById.get(n.id)
+    if (!box) return n   // containers + pills pass through untouched
+    return { ...n, position: { x: box.x, y: box.y } }
+  })
+}
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: no errors introduced; warnings unchanged.
+
+- [ ] **Step 3: Browser check**
+
+Run `npm run dev`, open a character with ≥ 5 orbitals, drag an orbital forcefully over a container. **Expected:** container and entry/exit pills do NOT move; only the dragged orbital (and any other orbitals it pushes) shift.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "fix(character-graph): scope drag collisions to orbital nodes"
+```
+
+---
+
+### Task 0.2: Persist orbital drag positions
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx` (props, `buildElements`, `handleNodeDragStop`)
+- Modify: `src/components/character-graph/CharacterGraphPage.tsx` (pass `moveNode` as prop)
+
+- [ ] **Step 1: Add `onPersistPosition` prop to `CharacterGraphCanvas`**
+
+In `CharacterGraphCanvas.tsx`, extend the `Props` interface (around line 577):
+
+```ts
+interface Props {
+  nodes: CharacterNode[]
+  selectedNodeId: number | null
+  synthesis: DomainSynthesis[]
+  synthesisLoading: string | null
+  onSelectNode: (id: number | null) => void
+  onContainerClick: (domain: CharacterNodeDomain) => void
+  onContextMenu?: (event: ContextMenuEvent) => void
+  /** Persists orbital drag-stop position. Pass `moveNode` from useCharacterGraph. */
+  onPersistPosition?: (id: number, x: number, y: number) => void
+}
+```
+
+And in the destructure (around line 587):
+
+```ts
+export function CharacterGraphCanvas({
+  nodes: charNodes,
+  selectedNodeId,
+  synthesis,
+  synthesisLoading,
+  onSelectNode,
+  onContainerClick,
+  onContextMenu,
+  onPersistPosition,
+}: Props) {
+```
+
+- [ ] **Step 2: Prefer persisted orbital positions in `buildElements`**
+
+In `buildElements` (lines 464-483), replace the orbital node creation block so it falls back to `getOrbitalPositions` only when `canvas_x === 0 && canvas_y === 0`. Target state:
+
+```ts
+    for (let i = 0; i < domainNodes.length; i++) {
+      const cn = domainNodes[i]
+      const size = getSalienceSize(cn.salience)
+
+      // Persisted position wins; fallback to computed layout if never dragged.
+      const hasPersisted = cn.canvas_x !== 0 || cn.canvas_y !== 0
+      const layoutPos = orbitalPos[i]
+      const position = hasPersisted
+        ? { x: cn.canvas_x, y: cn.canvas_y }
+        : { x: layoutPos.x - size / 2, y: layoutPos.y - size / 2 }
+
+      nodes.push({
+        id: `node-${cn.id}`,
+        type: 'child',
+        position,
+        draggable: true,
+        selectable: true,
+        data: {
+          nodeId: cn.id,
+          label: cn.label,
+          color: meta.color,
+          salience: cn.salience,
+          isSelected: cn.id === selectedId,
+          onSelect,
+        },
+      })
+
+      edges.push({
+        id: `orbital-edge-${cn.id}`,
+        source: `node-${cn.id}`,
+        target: `container-${meta.domain}`,
+        targetHandle: 'right',
+        type: 'straight',
+        animated: false,
+        style: {
+          stroke: meta.color,
+          strokeWidth: 1,
+          opacity: 0.3,
+        },
+      })
+    }
+```
+
+(The edge block is kept as-is for now. Task 1.3 migrates it to `floating`.)
+
+- [ ] **Step 3: Replace `handleNodeDragStop` to also persist**
+
+In `CharacterGraphCanvas.tsx` (lines 628-630), replace:
+
+```ts
+  const handleNodeDragStop = useCallback(() => {
+    setNodes(nds => resolveCollisions(nds))
+  }, [setNodes])
+```
+
+with:
+
+```ts
+  const handleNodeDragStop = useCallback(
+    (_: React.MouseEvent, draggedNode: Node) => {
+      setNodes(nds => resolveCollisions(nds))
+      // Only persist orbital positions. Containers/pills are not user-positioned yet (Fase 2).
+      if (draggedNode.type === 'child' && draggedNode.id.startsWith('node-') && onPersistPosition) {
+        const nodeId = parseInt(draggedNode.id.slice(5), 10)
+        if (!Number.isNaN(nodeId)) {
+          onPersistPosition(nodeId, draggedNode.position.x, draggedNode.position.y)
+        }
+      }
+    },
+    [setNodes, onPersistPosition],
+  )
+```
+
+Note: React Flow's `onNodeDragStop` signature is `(event, node, nodes) => void` — we use only `node`.
+
+- [ ] **Step 4: Wire `moveNode` from `CharacterGraphPage`**
+
+In `CharacterGraphPage.tsx`, destructure `moveNode` from `useCharacterGraph` (around line 32):
+
+```ts
+  const {
+    nodes, voiceRegister, chatMessages, characterName,
+    mode, selectedNodeId, loading, chatLoading, generating, error,
+    synthesis, synthesisLoading,
+    soul, soulLoading,
+    voiceExamples, premise, speechPattern, generatingExamples,
+    loadGraph, removeNode, editNode, moveNode,
+    updateVoice, saveExamples, generateExamples, sendMessage, generateNodes, clearChat,
+    toggleMode, setSelectedNodeId,
+    addFromCatalog, addFromContextual, regenerateSynthesis,
+    regenerateSoul,
+  } = useCharacterGraph(characterId)
+```
+
+Then pass it to the canvas (around line 211-219):
+
+```tsx
+              <CharacterGraphCanvas
+                nodes={nodes}
+                selectedNodeId={selectedNodeId}
+                synthesis={synthesis}
+                synthesisLoading={synthesisLoading}
+                onSelectNode={handleSelectNode}
+                onContainerClick={handleContainerClick}
+                onContextMenu={handleContextMenu}
+                onPersistPosition={moveNode}
+              />
+```
+
+- [ ] **Step 5: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no TS errors, no new lint errors.
+
+- [ ] **Step 6: Browser check**
+
+Open a character with ≥ 3 orbitals. Drag one orbital 200px in any direction. **Hard refresh** (Ctrl+Shift+R). **Expected:** the orbital reappears at its dragged position, not back in the layout slot.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx src/components/character-graph/CharacterGraphPage.tsx
+git commit -m "feat(character-graph): persist orbital drag positions"
+```
+
+---
+
+### Task 0.3: Drawer-aware `fitView`
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx`
+
+- [ ] **Step 1: Add `drawerOpen` prop**
+
+Extend `Props` (from Task 0.2):
+
+```ts
+interface Props {
+  // ...existing props
+  onPersistPosition?: (id: number, x: number, y: number) => void
+  /** When the right-side drawer opens/closes, canvas refits to compensate. */
+  drawerOpen: boolean
+}
+```
+
+And destructure it:
+
+```ts
+export function CharacterGraphCanvas({
+  ...,
+  onPersistPosition,
+  drawerOpen,
+}: Props) {
+```
+
+- [ ] **Step 2: Split the component into outer + inner, wrap in `ReactFlowProvider`**
+
+`useReactFlow()` only works inside `<ReactFlowProvider>`. Today the canvas is one component; the cheapest refactor is to split it.
+
+Add to the imports at the top of the file:
+
+```ts
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  Background,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  Handle,
+  Position,
+  NodeToolbar,
+  MarkerType,
+  type Node,
+  type Edge,
+  type NodeProps,
+} from '@xyflow/react'
+```
+
+Then rename the exported function `CharacterGraphCanvas` to `CharacterGraphCanvasInner` (keep everything the same internally), and add a new wrapper export below it:
+
+```ts
+function CharacterGraphCanvasInner(props: Props) {
+  // ...all the existing logic unchanged, up to and including the <ReactFlow>…</ReactFlow> return
+}
+
+export function CharacterGraphCanvas(props: Props) {
+  return (
+    <ReactFlowProvider>
+      <CharacterGraphCanvasInner {...props} />
+    </ReactFlowProvider>
+  )
+}
+```
+
+Internal name change is invisible to `CharacterGraphPage.tsx` — only the exported `CharacterGraphCanvas` is imported.
+
+- [ ] **Step 3: Refit canvas on drawer toggle**
+
+Inside `CharacterGraphCanvasInner`, import `useReducedMotion` from framer-motion at the top of the file if not already imported:
+
+```ts
+import { useReducedMotion } from 'framer-motion'
+```
+
+Add the effect near the other `useEffect`s (around line 623):
+
+```ts
+  const reactFlow = useReactFlow()
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    // Debounced slightly so it runs AFTER the drawer's transition starts occupying space.
+    const t = window.setTimeout(() => {
+      reactFlow.fitView({
+        padding: 0.12,
+        duration: prefersReducedMotion ? 0 : 250,
+      })
+    }, 120)
+    return () => window.clearTimeout(t)
+  }, [drawerOpen, reactFlow, prefersReducedMotion])
+```
+
+The 120ms delay roughly matches shadcn's default Sheet animation so the canvas refits once the drawer is visually in place.
+
+- [ ] **Step 4: Pass `drawerOpen` from the page**
+
+In `CharacterGraphPage.tsx`, pass the prop alongside the others (update the block you changed in Task 0.2):
+
+```tsx
+              <CharacterGraphCanvas
+                nodes={nodes}
+                selectedNodeId={selectedNodeId}
+                synthesis={synthesis}
+                synthesisLoading={synthesisLoading}
+                onSelectNode={handleSelectNode}
+                onContainerClick={handleContainerClick}
+                onContextMenu={handleContextMenu}
+                onPersistPosition={moveNode}
+                drawerOpen={selectedContainer !== null}
+              />
+```
+
+- [ ] **Step 5: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no TS errors.
+
+- [ ] **Step 6: Browser check**
+
+Open a character, click a container to open the catalog drawer. **Expected:** the canvas smoothly refits within ~250ms so all 5 containers remain visible (not cut off by the drawer). Close the drawer — the canvas refits again to fill the freed space.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx src/components/character-graph/CharacterGraphPage.tsx
+git commit -m "feat(character-graph): refit canvas when catalog drawer toggles"
+```
+
+---
+
+### Task 0.4: Rename `GraphMinimap` → `DecisionFlowOutline`
+
+**Files:**
+- Rename: `src/components/character-graph/GraphMinimap.tsx` → `src/components/character-graph/DecisionFlowOutline.tsx`
+- Modify: `src/components/character-graph/CharacterGraphPage.tsx` (import)
+
+- [ ] **Step 1: Git-rename the file**
+
+Run: `git mv src/components/character-graph/GraphMinimap.tsx src/components/character-graph/DecisionFlowOutline.tsx`
+
+- [ ] **Step 2: Rename the exported component inside the file**
+
+Open `src/components/character-graph/DecisionFlowOutline.tsx`. Replace the export line (was line 22):
+
+```ts
+export function GraphMinimap({ nodes, selectedNodeId, onSelectNode, onRemoveNode }: Props) {
+```
+
+with:
+
+```ts
+export function DecisionFlowOutline({ nodes, selectedNodeId, onSelectNode, onRemoveNode }: Props) {
+```
+
+No other references to `GraphMinimap` exist inside the file (it's self-contained).
+
+- [ ] **Step 3: Update the import in the page**
+
+In `src/components/character-graph/CharacterGraphPage.tsx`, change line 8:
+
+```ts
+import { GraphMinimap } from './GraphMinimap'
+```
+
+to:
+
+```ts
+import { DecisionFlowOutline } from './DecisionFlowOutline'
+```
+
+And change the usage at line 346:
+
+```tsx
+                <GraphMinimap
+                  nodes={nodes}
+                  selectedNodeId={selectedNodeId}
+                  onSelectNode={(id) => setSelectedNodeId(id)}
+                  onRemoveNode={handleRemoveNode}
+                />
+```
+
+to:
+
+```tsx
+                <DecisionFlowOutline
+                  nodes={nodes}
+                  selectedNodeId={selectedNodeId}
+                  onSelectNode={(id) => setSelectedNodeId(id)}
+                  onRemoveNode={handleRemoveNode}
+                />
+```
+
+- [ ] **Step 4: Grep for stragglers**
+
+Run: `git grep -n "GraphMinimap"`
+Expected: no results. If any remain, update them (no other call sites are known).
+
+- [ ] **Step 5: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 6: Browser check**
+
+Switch to "Hablar" mode for a character with nodes. **Expected:** the vertical pipeline outline on the left still renders identically.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/character-graph/
+git commit -m "refactor(character-graph): rename GraphMinimap to DecisionFlowOutline"
+```
+
+---
+
+### Task 0.5: Keyboard and screen-reader affordances on custom nodes
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx` (`ContainerNode`, `OrbitalNode`)
+
+- [ ] **Step 1: Make `ContainerNode` keyboard-accessible**
+
+Target state of the outer `<div>` in `ContainerNode` (around lines 126-139). Replace with:
+
+```tsx
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Dominio ${data.label as string}, ${data.childCount as number} nodos`}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          e.stopPropagation()
+          // Container click is handled at ReactFlow level via onNodeClick; simulate the same by
+          // dispatching a click on self — React Flow catches it through event bubbling.
+          ;(e.currentTarget as HTMLElement).click()
+        }
+      }}
+      className="rounded-xl overflow-hidden transition-all duration-300 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-500 focus-visible:outline-offset-2"
+      style={{
+        width: CONTAINER_WIDTH,
+        height: CONTAINER_HEIGHT,
+        background: data.bg as string,
+        border: isEmpty
+          ? `2px dashed ${data.color}28`
+          : isStale
+          ? `2px solid #F59E0B`
+          : `2px solid ${data.color}35`,
+        opacity: isEmpty ? 0.5 : 1,
+      }}
+    >
+```
+
+(The `click()` dispatch is how we trigger the existing `handleNodeClick` without duplicating logic. React Flow's `onNodeClick` listens for clicks inside the node element.)
+
+- [ ] **Step 2: Make `OrbitalNode` keyboard-accessible**
+
+Replace the outer `<div>` in `OrbitalNode` (around lines 252-281) with:
+
+```tsx
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={`${data.label as string}, intensidad ${data.salience as number}/10`}
+        aria-pressed={isSelected}
+        className="cursor-pointer rounded-full transition-all duration-150 hover:scale-110 flex items-center justify-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-500 focus-visible:outline-offset-2"
+        style={{
+          width: size,
+          height: size,
+          background: color,
+          boxShadow: isSelected
+            ? `0 0 0 3px white, 0 0 0 5px ${color}`
+            : `0 2px 8px ${color}40`,
+        }}
+        onClick={(e) => { e.stopPropagation(); data.onSelect(data.nodeId as number) }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.stopPropagation()
+            data.onSelect(data.nodeId as number)
+          }
+        }}
+      >
+```
+
+- [ ] **Step 3: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 4: Browser check**
+
+With the dev server open, click anywhere in the canvas area, then repeatedly press Tab. When focus lands on a container or orbital, observe a visible amber focus ring. Press Enter — the orbital should toggle selection; the container should open the catalog drawer. Verify nothing you Tab-focus is invisible.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "feat(character-graph): keyboard + screen-reader affordances on custom nodes"
+```
+
+---
+
+## Phase 1 — Edges + Warmth
+
+### Task 1.1: Geometry helper for floating edges
+
+**Files:**
+- Create: `src/components/character-graph/edges/getEdgeParams.ts`
+
+- [ ] **Step 1: Create the directory and helper file**
+
+Write the full content of `src/components/character-graph/edges/getEdgeParams.ts`:
+
+```ts
+import { Position } from '@xyflow/react'
+import type { InternalNode, Node } from '@xyflow/react'
+
+/**
+ * Ported from React Flow's "Simple Floating Edges" example, adapted to v12:
+ *   - `node.internals.positionAbsolute` replaces v11's `nodeInternals.get().positionAbsolute`.
+ *   - `node.measured` supersedes `node.width/height`.
+ * The helper computes the intersection of the line connecting two node centers
+ * with each node's bounding box, so edges attach to the nearest side instead of
+ * a fixed handle.
+ */
+
+function getNodeIntersection(
+  intersectionNode: InternalNode<Node>,
+  targetNode: InternalNode<Node>,
+): { x: number; y: number } {
+  const iw = intersectionNode.measured?.width ?? 0
+  const ih = intersectionNode.measured?.height ?? 0
+  const tw = targetNode.measured?.width ?? 0
+  const th = targetNode.measured?.height ?? 0
+
+  const ipos = intersectionNode.internals.positionAbsolute
+  const tpos = targetNode.internals.positionAbsolute
+
+  const w = iw / 2
+  const h = ih / 2
+
+  const x2 = ipos.x + w
+  const y2 = ipos.y + h
+  const x1 = tpos.x + tw / 2
+  const y1 = tpos.y + th / 2
+
+  const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h)
+  const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h)
+  const a = 1 / (Math.abs(xx1) + Math.abs(yy1) || 1)
+  const xx3 = a * xx1
+  const yy3 = a * yy1
+  const x = w * (xx3 + yy3) + x2
+  const y = h * (yy3 - xx3) + y2
+
+  return { x, y }
+}
+
+function getEdgePosition(
+  node: InternalNode<Node>,
+  intersectionPoint: { x: number; y: number },
+): Position {
+  const nx = Math.round(node.internals.positionAbsolute.x)
+  const ny = Math.round(node.internals.positionAbsolute.y)
+  const nw = node.measured?.width ?? 0
+  const nh = node.measured?.height ?? 0
+  const px = Math.round(intersectionPoint.x)
+  const py = Math.round(intersectionPoint.y)
+
+  if (px <= nx + 1) return Position.Left
+  if (px >= nx + nw - 1) return Position.Right
+  if (py <= ny + 1) return Position.Top
+  if (py >= ny + nh - 1) return Position.Bottom
+  return Position.Top
+}
+
+export function getEdgeParams(
+  source: InternalNode<Node>,
+  target: InternalNode<Node>,
+): {
+  sx: number; sy: number
+  tx: number; ty: number
+  sourcePos: Position; targetPos: Position
+} {
+  const sourceIntersectionPoint = getNodeIntersection(source, target)
+  const targetIntersectionPoint = getNodeIntersection(target, source)
+  const sourcePos = getEdgePosition(source, sourceIntersectionPoint)
+  const targetPos = getEdgePosition(target, targetIntersectionPoint)
+  return {
+    sx: sourceIntersectionPoint.x,
+    sy: sourceIntersectionPoint.y,
+    tx: targetIntersectionPoint.x,
+    ty: targetIntersectionPoint.y,
+    sourcePos,
+    targetPos,
+  }
+}
+```
+
+- [ ] **Step 2: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors (file is unused by anything yet, so this is a type-check only).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/character-graph/edges/getEdgeParams.ts
+git commit -m "feat(character-graph): add floating-edge geometry helper (v12)"
+```
+
+---
+
+### Task 1.2: `FloatingEdge` component
+
+**Files:**
+- Create: `src/components/character-graph/edges/FloatingEdge.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Write the full content of `src/components/character-graph/edges/FloatingEdge.tsx`:
+
+```tsx
+import { BaseEdge, getBezierPath, useInternalNode } from '@xyflow/react'
+import type { EdgeProps } from '@xyflow/react'
+import { getEdgeParams } from './getEdgeParams'
+
+/**
+ * Bezier edge anchored at the intersection of the source/target node bounding
+ * boxes. Use for orbital ↔ container edges so lines never pile onto a single
+ * handle point.
+ */
+export function FloatingEdge({
+  id,
+  source,
+  target,
+  markerEnd,
+  markerStart,
+  style,
+}: EdgeProps) {
+  const sourceNode = useInternalNode(source)
+  const targetNode = useInternalNode(target)
+
+  if (!sourceNode || !targetNode) return null
+
+  const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(sourceNode, targetNode)
+
+  const [edgePath] = getBezierPath({
+    sourceX: sx,
+    sourceY: sy,
+    sourcePosition: sourcePos,
+    targetPosition: targetPos,
+    targetX: tx,
+    targetY: ty,
+  })
+
+  return (
+    <BaseEdge
+      id={id}
+      path={edgePath}
+      markerEnd={markerEnd}
+      markerStart={markerStart}
+      style={style}
+    />
+  )
+}
+```
+
+- [ ] **Step 2: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/character-graph/edges/FloatingEdge.tsx
+git commit -m "feat(character-graph): add FloatingEdge custom edge component"
+```
+
+---
+
+### Task 1.3: Migrate orbital edges to `floating` type
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx`
+
+- [ ] **Step 1: Register `edgeTypes`**
+
+Near the top of `CharacterGraphCanvas.tsx`, after the `nodeTypes` declaration (around line 290-295), add:
+
+```ts
+import { FloatingEdge } from './edges/FloatingEdge'
+
+const nodeTypes = {
+  container: ContainerNode,
+  child: OrbitalNode,
+  entry: EntryNode,
+  exit: ExitNode,
+}
+
+const edgeTypes = {
+  floating: FloatingEdge,
+}
+```
+
+The `import` line must be hoisted to the top of the file with the other imports — do not leave it mid-file. Move it up alongside the existing `@xyflow/react` import.
+
+- [ ] **Step 2: Pass `edgeTypes` to `<ReactFlow>`**
+
+In the JSX return (around line 678), add the prop:
+
+```tsx
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      nodeTypes={nodeTypes}
+      edgeTypes={edgeTypes}
+      onPaneClick={handlePaneClick}
+      onNodeClick={handleNodeClick}
+      onNodeDragStop={handleNodeDragStop}
+      onNodeContextMenu={handleNodeContextMenu}
+      fitView
+      fitViewOptions={{ padding: 0.12 }}
+      minZoom={0.5}
+      maxZoom={1.5}
+      className="bg-[hsl(40_20%_97%)]"
+      proOptions={{ hideAttribution: true }}
+    >
+```
+
+- [ ] **Step 3: Switch orbital edges to `floating`**
+
+Inside `buildElements`, replace the orbital edge push (lines 486-498) with:
+
+```ts
+      edges.push({
+        id: `orbital-edge-${cn.id}`,
+        source: `node-${cn.id}`,
+        target: `container-${meta.domain}`,
+        type: 'floating',
+        style: {
+          stroke: meta.color,
+          strokeWidth: 1,
+          opacity: 0.35,
+        },
+      })
+```
+
+Note: `targetHandle: 'right'` is intentionally removed — floating edges compute anchor points themselves. `animated: false` is also removed; it was the default.
+
+- [ ] **Step 4: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 5: Browser check**
+
+Open a character with orbitals in ≥ 2 domains. Drag an orbital above the container midline, then below it. **Expected:** the edge re-anchors to the nearest side of the container (top vs. bottom) instead of always going to the right-middle point. With 5+ orbitals stacked, edges no longer converge on one spot.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "feat(character-graph): orbital edges now float to nearest container side"
+```
+
+---
+
+### Task 1.4: `LiteraryFlowEdge` component
+
+**Files:**
+- Create: `src/components/character-graph/edges/LiteraryFlowEdge.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Write the full content of `src/components/character-graph/edges/LiteraryFlowEdge.tsx`:
+
+```tsx
+import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath } from '@xyflow/react'
+import type { EdgeProps } from '@xyflow/react'
+import { useReducedMotion } from 'framer-motion'
+
+interface LiteraryFlowEdgeData extends Record<string, unknown> {
+  label: string
+  /** Hex color of the source domain — drives ink-pool and particle color. */
+  domainColor: string
+  /** Index of this edge in the chain (0..3); staggers the particle animation. */
+  chainIndex: number
+}
+
+/**
+ * Custom edge for the 4 domain-chain edges (CREENCIAS → MIEDOS → … → MASCARAS).
+ * - Path: smoothstep (preserves the existing vertical cascade).
+ * - Label: rendered in the HTML layer via EdgeLabelRenderer so real Lora italic
+ *   can be used (SVG <text> rendered the serif poorly).
+ * - Ink-pool: small SVG circle at 20% of the path in the domain color.
+ * - Particle: an animated circle gliding from source to target, reinforcing
+ *   the "causation flows downward" metaphor. Respects prefers-reduced-motion.
+ */
+export function LiteraryFlowEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  style,
+  data,
+}: EdgeProps) {
+  const prefersReducedMotion = useReducedMotion()
+  const edgeData = (data ?? {}) as Partial<LiteraryFlowEdgeData>
+  const label = edgeData.label ?? ''
+  const domainColor = edgeData.domainColor ?? '#a8a29e'
+  const chainIndex = edgeData.chainIndex ?? 0
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  })
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+
+      {/* Ink-pool: static dot at 20% of the path so the label has a visual anchor. */}
+      <circle r={3} fill={domainColor}>
+        <animateMotion
+          dur="0.001s"
+          repeatCount="1"
+          fill="freeze"
+          keyPoints="0.2;0.2"
+          keyTimes="0;1"
+          path={edgePath}
+        />
+      </circle>
+
+      {/* Animated particle — or static dot if reduced-motion. */}
+      {prefersReducedMotion ? (
+        <circle r={3} fill={domainColor} opacity={0.7}>
+          <animateMotion
+            dur="0.001s"
+            repeatCount="1"
+            fill="freeze"
+            keyPoints="0.5;0.5"
+            keyTimes="0;1"
+            path={edgePath}
+          />
+        </circle>
+      ) : (
+        <circle r={3} fill={domainColor} opacity={0.85}>
+          <animateMotion
+            dur="4s"
+            repeatCount="indefinite"
+            path={edgePath}
+            begin={`${chainIndex}s`}
+          />
+        </circle>
+      )}
+
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            className="absolute pointer-events-auto font-display italic text-[11px] leading-snug text-stone-500 bg-[hsl(40_20%_97%)]/90 px-2 py-0.5 rounded-sm"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}
+```
+
+- [ ] **Step 2: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/character-graph/edges/LiteraryFlowEdge.tsx
+git commit -m "feat(character-graph): add LiteraryFlowEdge with EdgeLabelRenderer"
+```
+
+---
+
+### Task 1.5: Migrate domain-chain edges to `literaryFlow`
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx`
+
+- [ ] **Step 1: Register the new edge type**
+
+Extend the import and `edgeTypes` declaration from Task 1.3:
+
+```ts
+import { FloatingEdge } from './edges/FloatingEdge'
+import { LiteraryFlowEdge } from './edges/LiteraryFlowEdge'
+
+// ...
+
+const edgeTypes = {
+  floating: FloatingEdge,
+  literaryFlow: LiteraryFlowEdge,
+}
+```
+
+- [ ] **Step 2: Replace the `flowPath` edge push**
+
+In `buildElements`, find the `for (const { from, to, label } of flowPath)` loop (lines 522-556). Replace it with:
+
+```ts
+  for (let idx = 0; idx < flowPath.length; idx++) {
+    const { from, to, label } = flowPath[idx]
+    const fromMeta = ALL_CONTAINERS.find(c => c.domain === from)
+    const color = fromMeta?.color ?? '#a8a29e'
+    edges.push({
+      id: `flow-${from}-${to}`,
+      source: `container-${from}`,
+      target: `container-${to}`,
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+      type: 'literaryFlow',
+      data: {
+        label,
+        domainColor: color,
+        chainIndex: idx,
+      },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: `${color}90`,
+        width: 16,
+        height: 16,
+      },
+      style: {
+        stroke: `${color}70`,
+        strokeWidth: 2,
+      },
+    })
+  }
+```
+
+Note: the `label`, `labelStyle`, `labelBgStyle`, `labelBgPadding`, `labelBgBorderRadius` fields are removed — `LiteraryFlowEdge` renders the label itself via `EdgeLabelRenderer`. `animated: false` is removed (default).
+
+- [ ] **Step 3: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 4: Browser check**
+
+Open a character with ≥ 3 domain containers populated. **Expected:**
+1. The 4 chain labels ("lo que da por hecho define lo que teme perder", …) render in **real Lora italic** (serif with proper kerning), not SVG text.
+2. A small colored ink-dot sits near the start of each chain edge.
+3. A second colored dot glides from source container to target container on a 4s loop, staggered across the 4 edges.
+4. With DevTools → Rendering → "Emulate CSS prefers-reduced-motion" set to "reduce", the moving dot freezes at the path midpoint.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "feat(character-graph): domain chain uses literaryFlow edge with animated particle"
+```
+
+---
+
+### Task 1.6: Barrel export for edges
+
+**Files:**
+- Create: `src/components/character-graph/edges/index.ts`
+
+- [ ] **Step 1: Create the barrel**
+
+Write the full content of `src/components/character-graph/edges/index.ts`:
+
+```ts
+export { FloatingEdge } from './FloatingEdge'
+export { LiteraryFlowEdge } from './LiteraryFlowEdge'
+export { getEdgeParams } from './getEdgeParams'
+```
+
+- [ ] **Step 2: Collapse imports in `CharacterGraphCanvas.tsx`**
+
+Replace the two separate imports from Tasks 1.3 and 1.5:
+
+```ts
+import { FloatingEdge } from './edges/FloatingEdge'
+import { LiteraryFlowEdge } from './edges/LiteraryFlowEdge'
+```
+
+with:
+
+```ts
+import { FloatingEdge, LiteraryFlowEdge } from './edges'
+```
+
+- [ ] **Step 3: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/character-graph/edges/index.ts src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "refactor(character-graph): barrel-export edge components"
+```
+
+---
+
+### Task 1.7: Official `<MiniMap />`
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx`
+
+- [ ] **Step 1: Import `MiniMap`**
+
+Extend the existing `@xyflow/react` import block:
+
+```ts
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  Background,
+  MiniMap,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  Handle,
+  Position,
+  NodeToolbar,
+  MarkerType,
+  type Node,
+  type Edge,
+  type NodeProps,
+} from '@xyflow/react'
+```
+
+- [ ] **Step 2: Render `<MiniMap />`**
+
+Inside `<ReactFlow>`, before the existing `<Background>`, add:
+
+```tsx
+      <MiniMap
+        position="bottom-right"
+        nodeColor={(n) => (n.data?.color as string | undefined) ?? '#c4b9ae'}
+        nodeStrokeWidth={0}
+        maskColor="rgba(120, 113, 108, 0.12)"
+        bgColor="hsl(40 20% 97%)"
+        pannable
+        zoomable
+        style={{ border: '1px solid #e7e0d8', borderRadius: 8 }}
+      />
+```
+
+`n.data?.color` exists for both `ContainerNode` and `OrbitalNode`. Entry/exit pills return the fallback beige.
+
+- [ ] **Step 3: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 4: Browser check**
+
+Open a character graph. **Expected:** a minimap appears at the bottom-right, showing all 5 containers as small colored rectangles (indigo/red/amber/emerald/violet — matching the domain colors) and orbitals as small colored dots. Drag inside the minimap to pan the main canvas; scroll over the minimap to zoom.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "feat(character-graph): add official MiniMap with domain coloring"
+```
+
+---
+
+### Task 1.8: Per-domain glyphs
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx`
+
+- [ ] **Step 1: Import the icons, verify `VenetianMask` exists**
+
+Replace the existing `lucide-react` import (line 17) with:
+
+```ts
+import { BookOpen, RefreshCw, Sprout, Flame, Compass, Zap, VenetianMask } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+```
+
+Run `npm run build` immediately. If `VenetianMask` is not exported by the installed `lucide-react` version, the build fails with a clear TS error. In that case, replace `VenetianMask` with `Drama` in both the import and the `ALL_CONTAINERS` mapping below. If `Drama` also fails, fall back to `Shield`.
+
+- [ ] **Step 2: Extend `ContainerMeta` with an `icon` field**
+
+Replace the `ContainerMeta` interface (around lines 22-28) and the `ALL_CONTAINERS` array (lines 30-36):
+
+```ts
+interface ContainerMeta {
+  domain: CharacterNodeDomain
+  label: string
+  subtitle: string
+  color: string
+  bg: string
+  icon: LucideIcon
+}
+
+const ALL_CONTAINERS: ContainerMeta[] = [
+  { domain: 'origin', label: 'CREENCIAS', subtitle: '¿Que da por hecho?', color: '#6366F1', bg: '#eef2ff', icon: Sprout },
+  { domain: 'fear',   label: 'MIEDOS',    subtitle: '¿Que evita?',        color: '#EF4444', bg: '#fef2f2', icon: Flame },
+  { domain: 'drive',  label: 'DESEOS',    subtitle: '¿Que persigue?',     color: '#F59E0B', bg: '#fffbeb', icon: Compass },
+  { domain: 'bond',   label: 'GRIETAS',   subtitle: '¿Donde se rompe?',   color: '#8B5CF6', bg: '#f5f3ff', icon: Zap },
+  { domain: 'mask',   label: 'MASCARAS',  subtitle: '¿Que muestra?',      color: '#10B981', bg: '#ecfdf5', icon: VenetianMask },
+]
+```
+
+- [ ] **Step 3: Pass the icon through `ContainerData` and render it**
+
+Extend the `ContainerData` interface (around lines 107-117) with:
+
+```ts
+interface ContainerData extends Record<string, unknown> {
+  domain: string
+  label: string
+  subtitle: string
+  color: string
+  bg: string
+  childCount: number
+  synthesis: string
+  isStale: boolean
+  isSynthesisLoading: boolean
+  icon: LucideIcon
+}
+```
+
+Then in `ContainerNode`, replace the header `<BookOpen />` (line 153):
+
+```tsx
+        <BookOpen className="w-4 h-4 shrink-0 opacity-40" style={{ color: data.color as string }} />
+```
+
+with:
+
+```tsx
+        {(() => {
+          const Icon = data.icon as LucideIcon
+          return <Icon className="w-4 h-4 shrink-0 opacity-40" style={{ color: data.color as string }} />
+        })()}
+```
+
+The IIFE is there because `data.icon` isn't a capitalized identifier in scope — JSX needs a capitalized component reference.
+
+- [ ] **Step 4: Pass `icon` into the node data**
+
+In `buildElements`, update the container node data block (lines 447-458):
+
+```ts
+    nodes.push({
+      id: `container-${meta.domain}`,
+      type: 'container',
+      position: pos,
+      draggable: true,
+      selectable: true,
+      data: {
+        domain: meta.domain,
+        label: meta.label,
+        subtitle: meta.subtitle,
+        color: meta.color,
+        bg: meta.bg,
+        childCount,
+        synthesis: domainSynth?.synthesis || '',
+        isStale: domainSynth?.is_stale ?? false,
+        isSynthesisLoading: synthesisLoading === meta.domain,
+        icon: meta.icon,
+      },
+    })
+```
+
+- [ ] **Step 5: Remove the now-unused `BookOpen` import**
+
+Adjust the import line from Step 1:
+
+```ts
+import { RefreshCw, Sprout, Flame, Compass, Zap, VenetianMask } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+```
+
+- [ ] **Step 6: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors; no unused-import warnings.
+
+- [ ] **Step 7: Browser check**
+
+Open a character graph. **Expected:** each of the 5 container headers shows a unique icon in its domain color — sprout for CREENCIAS, flame for MIEDOS, compass for DESEOS, zap for GRIETAS, mask for MASCARAS. No `BookOpen` anywhere.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "feat(character-graph): per-domain lucide glyphs replace repeated BookOpen"
+```
+
+---
+
+### Task 1.9: Layered paper background
+
+**Files:**
+- Modify: `src/components/character-graph/CharacterGraphCanvas.tsx`
+
+- [ ] **Step 1: Import `BackgroundVariant`**
+
+Extend the `@xyflow/react` import:
+
+```ts
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  Background,
+  BackgroundVariant,
+  MiniMap,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  Handle,
+  Position,
+  NodeToolbar,
+  MarkerType,
+  type Node,
+  type Edge,
+  type NodeProps,
+} from '@xyflow/react'
+```
+
+- [ ] **Step 2: Replace the single `<Background />` with two layers**
+
+In the JSX return, replace:
+
+```tsx
+      <Background color="#e8e0d4" gap={20} size={1} />
+```
+
+with:
+
+```tsx
+      <Background
+        id="paper"
+        variant={BackgroundVariant.Lines}
+        color="#efe6d7"
+        lineWidth={0.4}
+        gap={32}
+      />
+      <Background
+        id="dots"
+        variant={BackgroundVariant.Dots}
+        color="#d6cdbe"
+        gap={20}
+        size={1}
+      />
+```
+
+- [ ] **Step 3: Warm up the canvas base tint**
+
+Change the `className` on `<ReactFlow>` (around line 691) from:
+
+```tsx
+      className="bg-[hsl(40_20%_97%)]"
+```
+
+to:
+
+```tsx
+      className="bg-[hsl(40_30%_96%)]"
+```
+
+- [ ] **Step 4: Lint + build**
+
+Run: `npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 5: Browser check**
+
+Open a character graph, pan around. **Expected:** background shows a subtle horizontal-line rule (like journal paper) with sparse dots overlaid. Base color is clearly warm-cream, not gray. No moiré at default zoom.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/character-graph/CharacterGraphCanvas.tsx
+git commit -m "feat(character-graph): layered paper + dots background and warmer base tint"
+```
+
+---
+
+## Final verification
+
+### Task 2.0: End-to-end browser pass
+
+- [ ] **Step 1: Run the full pipeline**
+
+```bash
+npm run lint
+npm run build
+npm run dev
+```
+
+- [ ] **Step 2: Walk the 12-point spec verification list**
+
+Open a character with ≥ 10 nodes across ≥ 3 domains and walk through §7 of `docs/superpowers/specs/2026-04-16-character-graph-edges-warmth-design.md`:
+
+1. Drag an orbital near a container → container does NOT move.
+2. Click container → catalog drawer opens → canvas refits within ~250ms.
+3. Drag an orbital, hard-refresh → position persists.
+4. `npm run build` passes (already run above).
+5. Tab into canvas → orbital focus ring visible → Enter selects it.
+6. Drag orbital above container midline → orbital edge re-anchors to top.
+7. Zoom to 1.0 over a flow label → renders in Lora italic.
+8. Watch 4 gotas flow across the chain, staggered. DevTools reduced-motion → freezes at midpoint.
+9. Minimap shows 5 colored containers + dots.
+10. Each container has its distinct glyph.
+11. Background shows paper lines + dots, warm tint.
+
+- [ ] **Step 3: Close out the branch cleanly**
+
+No commit. If any step above fails, fix it before declaring the phase shipped. If everything passes, the branch is ready for PR review per the `superpowers:finishing-a-development-branch` skill.
+
+---
+
+## Self-review notes
+
+**Spec coverage:** Every section of the spec (§4.1.1–§4.1.5 and §4.2.1–§4.2.6) maps to at least one task:
+- §4.1.1 → Task 0.1
+- §4.1.2 → Task 0.3
+- §4.1.3 → Task 0.2
+- §4.1.4 → Task 0.4
+- §4.1.5 → Task 0.5
+- §4.2.1 → Tasks 1.1, 1.2, 1.3
+- §4.2.2 → Tasks 1.4, 1.5
+- §4.2.3 → Task 1.4 (particle) + Task 1.5 (wiring)
+- §4.2.4 → Task 1.7
+- §4.2.5 → Task 1.8
+- §4.2.6 → Task 1.9
+
+Barrel export (Task 1.6) is a housekeeping step not in the spec but implied by the three-file edge module layout.
+
+**Placeholder scan:** No TBDs. The one "if VenetianMask doesn't exist, fall back to Drama then Shield" in Task 1.8 is a concrete fallback ladder with a clear trigger, not a placeholder.
+
+**Type consistency:** `ContainerData`/`ContainerMeta` both gain `icon` with identical typing (`LucideIcon`). `LiteraryFlowEdgeData` fields (`label`, `domainColor`, `chainIndex`) are read from `edge.data` in the edge component and set in `buildElements` — names match exactly. `onPersistPosition: (id: number, x: number, y: number) => void` matches the signature of `moveNode` in `useCharacterGraph.ts:103`.
+
+**Scope:** Two phases, 13 tasks, ~8 hours of work. Independent from backend, from Voz/Hablar modes, from VoiceTab. Could be split at the Phase 0/1 boundary but the spec explicitly asked for both together.

--- a/docs/superpowers/specs/2026-04-16-character-graph-edges-warmth-design.md
+++ b/docs/superpowers/specs/2026-04-16-character-graph-edges-warmth-design.md
@@ -1,0 +1,264 @@
+# Character Graph — Edges + Warmth (Fase 0 + Fase 1)
+
+**Fecha:** 2026-04-16
+**Scope:** `src/components/character-graph/CharacterGraphCanvas.tsx`, `CharacterGraphPage.tsx`, `GraphMinimap.tsx` (rename), `useCharacterGraph.ts` (consumir `moveNode` desde el canvas).
+**Tipo:** Rediseño UX + upgrade técnico sobre `@xyflow/react@12.10.1`. No toca backend, datos, modos Voz/Hablar, ni VoiceTab/CatalogDrawer más allá del enganche de `fitView`.
+
+Este spec entrega dos fases planificadas como sub-proyectos separados en el mismo branch: **Fase 0** (cleanup y trivial wins) y **Fase 1** (edges + warmth visual). Fase 2 (NodeResizer + Save/Restore + containers embossed) y Fase 3 (spine, breathing, torn-paper, intersection-drag, export) quedan fuera y se especificarán aparte.
+
+---
+
+## 1. Problema
+
+El canvas de creación de personaje (5 contenedores de dominio con nodos orbitales) funciona, pero tiene varios defectos visibles. Los dos que el usuario señaló — edges orbital→container convergiendo en un solo píxel, y containers rígidos — son los peores, pero la auditoría UX descubrió una docena de cosas más:
+
+1. **Edges feos.** Cada edge orbital→container usa `type: 'straight'` con `targetHandle: 'right'`, lo cual geometricamente colapsa N edges en un único punto sobre el borde derecho. Se ve como un sunburst. Cuando hay 5+ orbitals stacked verticalmente se cruzan entre sí y atraviesan el cuerpo del container.
+2. **`resolveCollisions` empuja containers y pills.** El resolver trata todos los nodos como rectángulos iguales, incluyendo los contenedores fijos y las pills de entry/exit (marcadas `draggable: false` pero no excluidas del array de colisiones). Un orbital arrastrado puede mover CREENCIAS hacia arriba.
+3. **Drawer tapa el canvas.** El `CatalogDrawer` de 340px se abre sobre el borde derecho; el canvas no refita. Los containers a `x=100` con width 250 quedan parcialmente ocultos.
+4. **Drag efímero.** `useCharacterGraph` ya expone `moveNode(id, x, y)` que persiste vía `updateNodePosition`, pero el canvas nunca lo llama. Recargar pierde el layout.
+5. **`GraphMinimap` mal nombrado.** No es un minimap — es un TOC listado por dominio usado en modo "Hablar". No hay minimap real en modo graph.
+6. **A11y ≈ 0.** Container y orbital son `<div>` con `onClick`, sin role, tabIndex, aria-label, ni keyboard handler.
+7. **Labels de flow en SVG text.** La cadena causal ("lo que da por hecho define lo que teme perder") usa `edge.label` en SVG; Lora no se renderiza bien, no hay hover, no hay click-to-ver-porqué.
+8. **`BookOpen` repetido 5 veces** en cada header de container. Dead weight visual.
+9. **La cadena psicológica no se siente como flujo.** Son 4 flechas smoothstep estáticas entre containers. No transmite causación.
+10. **Fondo neutro.** `hsl(40 20% 97%)` es casi gris. No dice "página de manuscrito".
+
+El #3 pain que la auditoría sacó — containers rígidos 250×300 — es real pero requiere NodeResizer + Save/Restore, y se aborda en Fase 2.
+
+---
+
+## 2. Objetivos
+
+- **Fase 0:** Matar bugs visibles en < 1h. Ship inmediato, sin cambios de aspecto.
+- **Fase 1:** El canvas deja de verse como "node-editor demo genérico" y empieza a sentirse como una página de diario literario, sin refactor arquitectónico.
+
+---
+
+## 3. No-objetivos
+
+- NodeResizer sobre containers (Fase 2).
+- Save/Restore del viewport completo (Fase 2).
+- Sub-flow / `parentId` / orbital-como-hijo-del-container (descartado — rompería el metáfora de "orbitals fuera del contenedor").
+- Spine vertical, containers embossed, salience breathing, torn-paper entry/exit, iluminación manuscrita (Fase 3).
+- Intersection-drag para reasignar dominio (Fase 3).
+- Export PNG (Fase 3).
+- Auto-layout dagre/ELK.
+- Dark mode / `colorMode` prop.
+- Refactor de `CharacterGraphPage` más allá de llamar a `useReactFlow().fitView()` y al rename del outline.
+- Tocar VoiceTab, CatalogDrawer interno, o modos Voz/Hablar.
+- Backend o modelo de datos.
+
+---
+
+## 4. Decisiones de diseño
+
+### 4.1 Fase 0 — Trivial wins (~1h total)
+
+#### 4.1.1 Whitelist de `resolveCollisions`
+
+`resolveCollisions` (CharacterGraphCanvas.tsx:327-369) acepta todos los nodos. Cambio: filtrar antes del loop para incluir únicamente nodos de tipo `'child'` (orbitals). Containers, entry, exit nunca se mueven por colisión.
+
+```ts
+const boxes: Box[] = nodes
+  .filter(n => n.type === 'child')
+  .map(n => ({ ... }))
+```
+
+Al devolver, sólo se actualizan los nodos cuyo id aparece en `boxes`; el resto pasa por identidad.
+
+#### 4.1.2 `fitView()` al abrir/cerrar drawer
+
+Hoy `fitView` corre solo al mount. Al abrirse el `CatalogDrawer`, el canvas no re-encuadra y 340px de containers quedan tapados.
+
+- Exponer `CharacterGraphCanvas` desde `<ReactFlowProvider>` (actualmente ya tiene `<ReactFlow>`, hay que envolverlo para poder usar `useReactFlow()` dentro).
+- Añadir prop `drawerOpen: boolean` al canvas.
+- `useEffect` sobre `drawerOpen` llama `reactFlow.fitView({ padding: 0.12, duration: 250 })`.
+- Respetar `prefers-reduced-motion` → `duration: 0` si reduce-motion está activo.
+
+#### 4.1.3 Persistir posiciones de orbitals
+
+`useCharacterGraph.moveNode(id, x, y)` ya escribe en backend vía `updateNodePosition`. El canvas lo ignora.
+
+- `CharacterGraphPage` pasa `moveNode` al canvas como prop.
+- `onNodeDragStop` en canvas: si `node.type === 'child'` y `node.id.startsWith('node-')`, extraer id numérico y llamar `moveNode(id, node.position.x, node.position.y)`.
+- `buildElements` en `CharacterGraphCanvas`: al crear cada orbital, preferir `charNode.canvas_x/canvas_y` si ambos son no-null; fallback a `getOrbitalPositions` si no hay posición persistida.
+- Containers, entry y exit no se persisten (Fase 2).
+
+#### 4.1.4 Rename `GraphMinimap` → `DecisionFlowOutline`
+
+El componente muestra un listado vertical por dominio con `↓` entre etapas. Es un outline/TOC, no un minimap.
+
+- Renombrar archivo y componente: `GraphMinimap.tsx` → `DecisionFlowOutline.tsx`, export `DecisionFlowOutline`.
+- Actualizar el único import en `CharacterGraphPage.tsx`.
+- Libera el nombre "MiniMap" para el componente oficial de React Flow en §4.2.4.
+
+#### 4.1.5 A11y básica en container y orbital
+
+Container (`ContainerNode`) y orbital (`OrbitalNode`) son `<div>` con `onClick`. Cambio:
+
+- Container: `role="button"`, `tabIndex={0}`, `aria-label={`Dominio ${label}, ${childCount} nodos`}`, `onKeyDown` que invoca el mismo handler en Enter y Space.
+- Orbital: `role="button"`, `tabIndex={0}`, `aria-label={`${label}, intensidad ${salience}/10`}`, `onKeyDown` para seleccionar.
+- Focus ring (no tocar el ring de `isSelected`): añadir `outline: 2px solid #f59e0b; outline-offset: 2px` cuando `:focus-visible` — Tailwind `focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-500 focus-visible:outline-offset-2`.
+- Estos cambios no modifican la navegación por teclado dentro del canvas de React Flow (la hemos dejado out-of-scope porque RF no expone focus por nodo nativamente). Es solo para que Enter/Space funcione si el usuario llega al nodo con Tab.
+
+### 4.2 Fase 1 — Edges + Warmth (~7h)
+
+#### 4.2.1 Simple Floating Edges (orbital ↔ container)
+
+Resuelve el pain #1.
+
+- Nuevo archivo: `src/components/character-graph/edges/FloatingEdge.tsx`.
+- Port literal del helper `getEdgeParams` del ejemplo oficial https://reactflow.dev/examples/edges/simple-floating-edges usando la API v12: `useInternalNode(id)`, `internals.positionAbsolute`, `internals.handleBounds`.
+- Componente: renderiza `<BaseEdge path={getBezierPath({ sx, sy, sourcePosition, tx, ty, targetPosition })[0]} />` con `style` pasado por props (incluye el color del dominio).
+- Registrar en `edgeTypes`: `{ floating: FloatingEdge }`.
+- `buildElements`: las edges orbital→container pasan a `type: 'floating'`, se elimina `targetHandle: 'right'`, se conservan `style.stroke`, `style.strokeWidth`, `style.opacity`.
+- Los handles invisibles `id="right"`/`id="left"`/`id="top"`/`id="bottom"` sobre `ContainerNode` (líneas 191-196) permanecen: las flow edges entre dominios (§4.2.2) siguen usando `bottom`/`top` con handles explícitos.
+- Flow edges entre dominios (origin→fear, fear→drive, etc.): **no** se migran a `floating` — la cadena debe fluir vertical por razones semánticas (CREENCIAS arriba, MÁSCARAS abajo). Su `type` cambia de `smoothstep` a `literaryFlow` en §4.2.2, pero la geometría del path sigue siendo smooth-step internamente (vía `getSmoothStepPath`) y los handles `sourceHandle: 'bottom'` + `targetHandle: 'top'` se conservan.
+
+#### 4.2.2 EdgeLabelRenderer para la cadena causal
+
+Los 4 flow edges tienen labels italicizados tipo "lo que da por hecho define lo que teme perder". Hoy renderizan en SVG text sin Lora real.
+
+- Nuevo archivo: `src/components/character-graph/edges/LiteraryFlowEdge.tsx`.
+- Usa `getSmoothStepPath` para el path SVG.
+- Renderiza `<BaseEdge />` + un `<EdgeLabelRenderer>` con:
+  - Un `<div>` absolutamente posicionado en el midpoint del path (`translate(-50%,-50%) translate(Xpx, Ypx)`).
+  - Clase: `pointer-events-auto font-display italic text-[11px] text-stone-500 bg-[hsl(40_20%_97%)]/90 px-2 py-0.5 rounded-sm`.
+  - `font-display` resuelve a Lora (definido en Tailwind config).
+- Un `<circle>` SVG en el path, en el 20% del recorrido, fill = color del dominio fuente, radio 3. Sirve como "ink pool" — inspiración del bolder audit.
+- Registrar en `edgeTypes`: `{ floating: FloatingEdge, literaryFlow: LiteraryFlowEdge }`.
+- `buildElements`: las 4 edges entre dominios pasan a `type: 'literaryFlow'`. El `label` sigue en `edge.data.label` (no en `edge.label`), porque el label ahora lo renderiza nuestro componente, no React Flow.
+
+#### 4.2.3 Animación de partícula en la cadena
+
+Una gota que fluye CREENCIAS → MÁSCARAS, reforzando la metáfora de causación.
+
+- Dentro de `LiteraryFlowEdge`, añadir un `<circle r="3" fill={domainColor}>` con `<animateMotion path={edgePath} dur="4s" repeatCount="indefinite" />`.
+- Gate por `prefers-reduced-motion`: hook `useReducedMotion()` de framer-motion (ya instalado). Si reducida, renderizar el círculo estático en el mismo 20% del path (sin `animateMotion`).
+- Escalonar las 4 edges con un `begin` incremental (0s, 1s, 2s, 3s) para que parezca un flujo continuo por la cadena.
+- Si perf empeora visiblemente en máquinas lentas (~40+ nodos), gate adicional por una prop `animated?: boolean` en el edge; default true, false cuando `orbitalCount > 30`.
+
+#### 4.2.4 Official `<MiniMap />` en modo graph
+
+El canvas es ~2140px de alto. El usuario se pierde al hacer zoom. El outline renombrado en §4.1.4 sigue siendo para modo "Hablar".
+
+- Importar `MiniMap` de `@xyflow/react`.
+- Renderizar dentro de `<ReactFlow>`:
+  ```tsx
+  <MiniMap
+    position="bottom-right"
+    nodeColor={(n) => (n.data.color as string) ?? '#c4b9ae'}
+    nodeStrokeWidth={0}
+    maskColor="rgba(120, 113, 108, 0.12)"
+    bgColor="hsl(40 20% 97%)"
+    pannable
+    zoomable
+    style={{ border: '1px solid #e7e0d8', borderRadius: 8 }}
+  />
+  ```
+- El color de cada nodo se lee de `data.color` (ya existe en containers y orbitals).
+- Colocar en `bottom-right`, al lado opuesto del Panel con la leyenda (`top-right`). No colisionan.
+
+#### 4.2.5 Cinco glifos de dominio
+
+Reemplazar `BookOpen` repetido en los 5 headers de container.
+
+- Mantener `lucide-react` como fuente (ya instalada). Mapeo propuesto:
+  - `origin` (CREENCIAS): `Sprout` — semilla, lo dado por hecho.
+  - `fear` (MIEDOS): `Flame` — lo que se evita, energía contenida.
+  - `drive` (DESEOS): `Compass` — orientación, lo perseguido. (Alternativa: `Target`.)
+  - `bond` (GRIETAS): `Zap` — fractura, descarga.
+  - `mask` (MÁSCARAS): `VenetianMask` — si existe en lucide (verificar). Fallback: `Shield` o `Eye`.
+- Añadir `icon: LucideIcon` al `ContainerMeta` en `ALL_CONTAINERS`.
+- `ContainerNode` renderiza `<Icon className="w-4 h-4 shrink-0 opacity-40" style={{ color }} />` en lugar del `BookOpen` hardcodeado.
+- Tamaño y opacidad idénticos al actual — no es un cambio de jerarquía, solo identidad.
+
+#### 4.2.6 Background layered (paper + dots)
+
+El fondo `hsl(40 20% 97%)` es casi gris. Objetivo: sensación de papel de cuaderno.
+
+- Reemplazar el único `<Background color="#e8e0d4" gap={20} size={1} />` actual por dos layers:
+  ```tsx
+  <Background id="paper" variant={BackgroundVariant.Lines}
+              color="#efe6d7" lineWidth={0.4} gap={32} />
+  <Background id="dots"  variant={BackgroundVariant.Dots}
+              color="#d6cdbe" gap={20} size={1} />
+  ```
+- El layer `paper` en `lineWidth` fino evoca rayado sutil de diario; los dots encima mantienen la textura actual.
+- Tint del canvas base: cambiar `className="bg-[hsl(40_20%_97%)]"` a `bg-[hsl(40_30%_96%)]` — un punto más cálido, casi imperceptible individualmente pero coherente con los nuevos glifos y la gota flotante.
+
+---
+
+## 5. Componentes modificados / creados
+
+### Nuevos
+
+- `src/components/character-graph/edges/FloatingEdge.tsx`
+- `src/components/character-graph/edges/LiteraryFlowEdge.tsx`
+- `src/components/character-graph/edges/getEdgeParams.ts` (helper geométrico)
+
+### Renombrados
+
+- `src/components/character-graph/GraphMinimap.tsx` → `src/components/character-graph/DecisionFlowOutline.tsx` (export `DecisionFlowOutline`).
+
+### Modificados
+
+- `CharacterGraphCanvas.tsx`:
+  - Envolver con `<ReactFlowProvider>` para poder usar `useReactFlow()` desde un hijo.
+  - Registrar `edgeTypes`.
+  - `buildElements`: orbital edges → `type: 'floating'`; flow edges → `type: 'literaryFlow'`.
+  - `ContainerNode`: icono por dominio, a11y props.
+  - `OrbitalNode`: a11y props + focus-visible.
+  - `resolveCollisions`: whitelist a `type === 'child'`.
+  - `buildElements`: preferir `charNode.canvas_x/canvas_y` para orbitals si existen.
+  - Añadir `<MiniMap />`.
+  - Dos layers de `<Background />`.
+  - Nueva prop `drawerOpen` + `useEffect` con `fitView`.
+  - Nueva prop `onPersistPosition` (pasada a `moveNode` desde la page).
+- `CharacterGraphPage.tsx`:
+  - Pasar `drawerOpen={selectedContainer !== null}` al canvas.
+  - Pasar `onPersistPosition={moveNode}` al canvas.
+  - Actualizar import `GraphMinimap` → `DecisionFlowOutline`.
+- `useCharacterGraph.ts`: **no cambia**. `moveNode` ya existe.
+
+---
+
+## 6. Riesgos y mitigaciones
+
+| Riesgo | Mitigación |
+|--------|------------|
+| `animateMotion` en Safari/iOS puede fallar o bajar FPS | Gate por `prefers-reduced-motion`; fallback a punto estático. Si se reporta, añadir feature flag env. |
+| `useInternalNode` en v12 no está todavía estable en el ejemplo | Mantener fallback: si `internals.positionAbsolute` es undefined, usar `node.position` (no-absoluto) — produce floating edges ligeramente off cuando hay `parentId`, pero en este canvas no hay parents. |
+| Rename de archivo rompe git blame | Usar `git mv` para que git detecte el rename. |
+| `VenetianMask` puede no existir en la versión de lucide instalada | Verificar en el archivo de types; fallback a `Drama` o `Shield`. Chequeo en el plan. |
+| Orbitals con `canvas_x`/`canvas_y` persistidos quedan dentro del área de otro dominio | No es un bug nuevo — ya puede pasar con el drag actual dentro de sesión. Fase 3 (intersection-drag) lo arregla. |
+| MiniMap en `bottom-right` colisiona con futuras panels | Posición configurable por prop, default `bottom-right`. |
+
+---
+
+## 7. Testing / verificación
+
+El repo no tiene framework de tests configurado (confirmado en `CLAUDE.md`). Verificación será manual en el dev server:
+
+1. Arrancar `npm run dev`, abrir un personaje con ≥ 10 nodos repartidos en ≥ 3 dominios.
+2. **Fase 0.1:** Arrastrar un orbital cerca de un container — verificar que el container NO se mueve.
+3. **Fase 0.2:** Click en container para abrir drawer — verificar que el canvas se reencuadra (containers no quedan cortados).
+4. **Fase 0.3:** Arrastrar un orbital, refrescar la página, verificar que la posición persiste.
+5. **Fase 0.4:** Build (`npm run build`) — verificar que el rename resuelve en TS y ESLint (`npm run lint`).
+6. **Fase 0.5:** Tab desde la barra superior hasta el canvas; Tab dentro — enter/space en un orbital lo selecciona.
+7. **Fase 1.1:** Arrastrar un orbital hacia arriba del container: la edge re-ancla al borde superior, no cruza el cuerpo.
+8. **Fase 1.2:** Zoom in al 1.0 en una flow edge — los labels se ven en Lora italic, no en sans SVG.
+9. **Fase 1.3:** Observar 4 gotas fluyendo por la cadena. Activar reduced-motion en DevTools → desaparecen, aparecen puntos estáticos.
+10. **Fase 1.4:** Scroll/zoom en el canvas mientras el MiniMap sigue mostrando los 5 colores de dominio.
+11. **Fase 1.5:** Cada container tiene su glifo (sprout, flame, compass, zap, mask/drama).
+12. **Fase 1.6:** Fondo tiene sensación de papel rayado suave + dots.
+
+Browser check mínimo: Chrome + Firefox recientes. Sin verificación en Safari móvil (out of scope).
+
+---
+
+## 8. Orden de implementación sugerido
+
+Fase 0 primero, entera, en un commit cohesionado (son cinco cambios pequeños, ninguno depende del siguiente). Fase 1 en 6 commits separados, uno por §4.2.1…§4.2.6, en ese orden — floating edges es el prerequisito visual; el resto son aditivos independientes y se pueden revertir individualmente si algo sale mal.
+
+Fin del spec.

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -327,7 +327,11 @@ const MARGIN = 12
 function resolveCollisions(nodes: Node[]): Node[] {
   type Box = { id: string; x: number; y: number; w: number; h: number }
 
-  const boxes: Box[] = nodes.map(n => ({
+  // Only orbital child nodes participate in collision resolution.
+  // Containers (type 'container') and entry/exit pills stay anchored.
+  const movable = nodes.filter(n => n.type === 'child')
+
+  const boxes: Box[] = movable.map(n => ({
     id: n.id,
     x: n.position.x,
     y: n.position.y,
@@ -348,12 +352,11 @@ function resolveCollisions(nodes: Node[]): Node[] {
         const overlapY = (a.h + b.h) / 2 - Math.abs(dy)
         if (overlapX > 0 && overlapY > 0) {
           moved = true
-          const push = overlapX < overlapY
-            ? overlapX / 2 * (dx > 0 ? 1 : -1)
-            : overlapY / 2 * (dy > 0 ? 1 : -1)
           if (overlapX < overlapY) {
+            const push = overlapX / 2 * (dx > 0 ? 1 : -1)
             a.x -= push; b.x += push
           } else {
+            const push = overlapY / 2 * (dy > 0 ? 1 : -1)
             a.y -= push; b.y += push
           }
         }
@@ -362,8 +365,10 @@ function resolveCollisions(nodes: Node[]): Node[] {
     if (!moved) break
   }
 
+  const boxById = new Map(boxes.map(b => [b.id, b]))
   return nodes.map(n => {
-    const box = boxes.find(b => b.id === n.id)!
+    const box = boxById.get(n.id)
+    if (!box) return n   // containers + pills pass through untouched
     return { ...n, position: { x: box.x, y: box.y } }
   })
 }

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -16,6 +16,7 @@ import {
   type NodeProps,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
+import { FloatingEdge } from './edges/FloatingEdge'
 import { useReducedMotion } from 'framer-motion'
 import { BookOpen, RefreshCw } from 'lucide-react'
 import type { CharacterNode, CharacterNodeDomain, DomainSynthesis } from '@/services/api'
@@ -318,6 +319,10 @@ const nodeTypes = {
   exit: ExitNode,
 }
 
+const edgeTypes = {
+  floating: FloatingEdge,
+}
+
 /* ── Calculate orbital positions ─────────────────────────────────── */
 
 function getOrbitalPositions(
@@ -521,13 +526,11 @@ function buildElements(
         id: `orbital-edge-${cn.id}`,
         source: `node-${cn.id}`,
         target: `container-${meta.domain}`,
-        targetHandle: 'right',
-        type: 'straight',
-        animated: false,
+        type: 'floating',
         style: {
           stroke: meta.color,
           strokeWidth: 1,
-          opacity: 0.3,
+          opacity: 0.35,
         },
       })
     }
@@ -758,6 +761,7 @@ function CharacterGraphCanvasInner({
       edges={edges}
       onNodesChange={onNodesChange}
       nodeTypes={nodeTypes}
+      edgeTypes={edgeTypes}
       onPaneClick={handlePaneClick}
       onNodeClick={handleNodeClick}
       onNodeDragStop={handleNodeDragStop}

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -4,6 +4,7 @@ import {
   ReactFlowProvider,
   useReactFlow,
   Background,
+  BackgroundVariant,
   MiniMap,
   Panel,
   useNodesState,
@@ -772,7 +773,7 @@ function CharacterGraphCanvasInner({
       fitViewOptions={{ padding: 0.12 }}
       minZoom={0.5}
       maxZoom={1.5}
-      className="bg-[hsl(40_20%_97%)]"
+      className="bg-[hsl(40_30%_96%)]"
       proOptions={{ hideAttribution: true }}
     >
       <MiniMap
@@ -786,7 +787,20 @@ function CharacterGraphCanvasInner({
         style={{ border: '1px solid #e7e0d8', borderRadius: 8 }}
       />
 
-      <Background color="#e8e0d4" gap={20} size={1} />
+      <Background
+        id="paper"
+        variant={BackgroundVariant.Lines}
+        color="#efe6d7"
+        lineWidth={0.4}
+        gap={32}
+      />
+      <Background
+        id="dots"
+        variant={BackgroundVariant.Dots}
+        color="#d6cdbe"
+        gap={20}
+        size={1}
+      />
 
       <Panel position="top-right">
         <div style={{

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -16,8 +16,7 @@ import {
   type NodeProps,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { FloatingEdge } from './edges/FloatingEdge'
-import { LiteraryFlowEdge } from './edges/LiteraryFlowEdge'
+import { FloatingEdge, LiteraryFlowEdge } from './edges'
 import { useReducedMotion } from 'framer-motion'
 import { BookOpen, RefreshCw } from 'lucide-react'
 import type { CharacterNode, CharacterNodeDomain, DomainSynthesis } from '@/services/api'

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -17,6 +17,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { FloatingEdge } from './edges/FloatingEdge'
+import { LiteraryFlowEdge } from './edges/LiteraryFlowEdge'
 import { useReducedMotion } from 'framer-motion'
 import { BookOpen, RefreshCw } from 'lucide-react'
 import type { CharacterNode, CharacterNodeDomain, DomainSynthesis } from '@/services/api'
@@ -321,6 +322,7 @@ const nodeTypes = {
 
 const edgeTypes = {
   floating: FloatingEdge,
+  literaryFlow: LiteraryFlowEdge,
 }
 
 /* ── Calculate orbital positions ─────────────────────────────────── */
@@ -556,37 +558,30 @@ function buildElements(
     },
   ]
 
-  for (const { from, to, label } of flowPath) {
+  for (let idx = 0; idx < flowPath.length; idx++) {
+    const { from, to, label } = flowPath[idx]
     const fromMeta = ALL_CONTAINERS.find(c => c.domain === from)
+    const color = fromMeta?.color ?? '#a8a29e'
     edges.push({
       id: `flow-${from}-${to}`,
       source: `container-${from}`,
       target: `container-${to}`,
       sourceHandle: 'bottom',
       targetHandle: 'top',
-      type: 'smoothstep',
-      animated: false,
-      label,
-      labelStyle: {
-        fontSize: 10,
-        fontStyle: 'italic',
-        fill: '#a8a29e',
-        fontFamily: 'Lora, Georgia, serif',
+      type: 'literaryFlow',
+      data: {
+        label,
+        domainColor: color,
+        chainIndex: idx,
       },
-      labelBgStyle: {
-        fill: 'hsl(40 20% 97%)',
-        fillOpacity: 0.9,
-      },
-      labelBgPadding: [6, 4] as [number, number],
-      labelBgBorderRadius: 4,
       markerEnd: {
         type: MarkerType.ArrowClosed,
-        color: `${fromMeta?.color}90`,
+        color: `${color}90`,
         width: 16,
         height: 16,
       },
       style: {
-        stroke: `${fromMeta?.color}70`,
+        stroke: `${color}70`,
         strokeWidth: 2,
       },
     })

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -468,13 +468,19 @@ function buildElements(
 
     for (let i = 0; i < domainNodes.length; i++) {
       const cn = domainNodes[i]
-      const oPos = orbitalPos[i]
       const size = getSalienceSize(cn.salience)
+
+      // Persisted position wins; fallback to computed layout if never dragged.
+      const hasPersisted = cn.canvas_x !== 0 || cn.canvas_y !== 0
+      const layoutPos = orbitalPos[i]
+      const position = hasPersisted
+        ? { x: cn.canvas_x, y: cn.canvas_y }
+        : { x: layoutPos.x - size / 2, y: layoutPos.y - size / 2 }
 
       nodes.push({
         id: `node-${cn.id}`,
         type: 'child',
-        position: { x: oPos.x - size / 2, y: oPos.y - size / 2 },
+        position,
         draggable: true,
         selectable: true,
         data: {
@@ -487,7 +493,6 @@ function buildElements(
         },
       })
 
-      // Edge from orbital (left) to container (right side)
       edges.push({
         id: `orbital-edge-${cn.id}`,
         source: `node-${cn.id}`,
@@ -587,6 +592,8 @@ interface Props {
   onSelectNode: (id: number | null) => void
   onContainerClick: (domain: CharacterNodeDomain) => void
   onContextMenu?: (event: ContextMenuEvent) => void
+  /** Persists orbital drag-stop position. Pass `moveNode` from useCharacterGraph. */
+  onPersistPosition?: (id: number, x: number, y: number) => void
 }
 
 export function CharacterGraphCanvas({
@@ -597,6 +604,7 @@ export function CharacterGraphCanvas({
   onSelectNode,
   onContainerClick,
   onContextMenu,
+  onPersistPosition,
 }: Props) {
   const handleSelectNode = useCallback(
     (id: number) => onSelectNode(id === selectedNodeId ? null : id),
@@ -630,9 +638,19 @@ export function CharacterGraphCanvas({
 
   const handlePaneClick = useCallback(() => onSelectNode(null), [onSelectNode])
 
-  const handleNodeDragStop = useCallback(() => {
-    setNodes(nds => resolveCollisions(nds))
-  }, [setNodes])
+  const handleNodeDragStop = useCallback(
+    (_: React.MouseEvent, draggedNode: Node) => {
+      setNodes(nds => resolveCollisions(nds))
+      // Only persist orbital positions. Containers/pills are not user-positioned yet (Fase 2).
+      if (draggedNode.type === 'child' && draggedNode.id.startsWith('node-') && onPersistPosition) {
+        const nodeId = parseInt(draggedNode.id.slice(5), 10)
+        if (!Number.isNaN(nodeId)) {
+          onPersistPosition(nodeId, draggedNode.position.x, draggedNode.position.y)
+        }
+      }
+    },
+    [setNodes, onPersistPosition],
+  )
 
   // ReactFlow-level click — works reliably unlike onClick inside custom nodes
   const handleNodeClick = useCallback((_: React.MouseEvent, node: Node) => {

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useEffect } from 'react'
+import { useMemo, useCallback, useEffect, useRef } from 'react'
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -642,19 +642,27 @@ function CharacterGraphCanvasInner({
   }, [flowNodes, setNodes])
   useEffect(() => { setEdges(flowEdges) }, [flowEdges, setEdges])
 
-  const reactFlow = useReactFlow()
+  const { fitView } = useReactFlow()
   const prefersReducedMotion = useReducedMotion()
+  const didMountRef = useRef(false)
 
   useEffect(() => {
-    // Debounced slightly so it runs AFTER the drawer's transition starts occupying space.
+    // Skip the first run: <ReactFlow fitView /> already handles initial layout.
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
+    // The drawer is a fixed-position Sheet portal — the canvas container does
+    // not reflow. This fitView re-centers so graph content is not occluded by
+    // the drawer overlay. 120ms matches the Sheet enter/exit cadence.
     const t = window.setTimeout(() => {
-      reactFlow.fitView({
+      fitView({
         padding: 0.12,
         duration: prefersReducedMotion ? 0 : 250,
       })
     }, 120)
     return () => window.clearTimeout(t)
-  }, [drawerOpen, reactFlow, prefersReducedMotion])
+  }, [drawerOpen, fitView, prefersReducedMotion])
 
   const handlePaneClick = useCallback(() => onSelectNode(null), [onSelectNode])
 

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -19,7 +19,8 @@ import {
 import '@xyflow/react/dist/style.css'
 import { FloatingEdge, LiteraryFlowEdge } from './edges'
 import { useReducedMotion } from 'framer-motion'
-import { BookOpen, RefreshCw } from 'lucide-react'
+import { RefreshCw, Sprout, Flame, Compass, Zap, VenetianMask } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import type { CharacterNode, CharacterNodeDomain, DomainSynthesis } from '@/services/api'
 
 /* ── Container metadata ────────────────────────────────────────── */
@@ -30,14 +31,15 @@ interface ContainerMeta {
   subtitle: string
   color: string
   bg: string
+  icon: LucideIcon
 }
 
 const ALL_CONTAINERS: ContainerMeta[] = [
-  { domain: 'origin', label: 'CREENCIAS', subtitle: '¿Que da por hecho?', color: '#6366F1', bg: '#eef2ff' },
-  { domain: 'fear',   label: 'MIEDOS',    subtitle: '¿Que evita?',        color: '#EF4444', bg: '#fef2f2' },
-  { domain: 'drive',  label: 'DESEOS',    subtitle: '¿Que persigue?',     color: '#F59E0B', bg: '#fffbeb' },
-  { domain: 'bond',   label: 'GRIETAS',   subtitle: '¿Donde se rompe?',   color: '#8B5CF6', bg: '#f5f3ff' },
-  { domain: 'mask',   label: 'MASCARAS',  subtitle: '¿Que muestra?',      color: '#10B981', bg: '#ecfdf5' },
+  { domain: 'origin', label: 'CREENCIAS', subtitle: '¿Que da por hecho?', color: '#6366F1', bg: '#eef2ff', icon: Sprout },
+  { domain: 'fear',   label: 'MIEDOS',    subtitle: '¿Que evita?',        color: '#EF4444', bg: '#fef2f2', icon: Flame },
+  { domain: 'drive',  label: 'DESEOS',    subtitle: '¿Que persigue?',     color: '#F59E0B', bg: '#fffbeb', icon: Compass },
+  { domain: 'bond',   label: 'GRIETAS',   subtitle: '¿Donde se rompe?',   color: '#8B5CF6', bg: '#f5f3ff', icon: Zap },
+  { domain: 'mask',   label: 'MASCARAS',  subtitle: '¿Que muestra?',      color: '#10B981', bg: '#ecfdf5', icon: VenetianMask },
 ]
 
 // Vertical flow — top to bottom, orbitals to the right
@@ -119,6 +121,7 @@ interface ContainerData extends Record<string, unknown> {
   synthesis: string
   isStale: boolean
   isSynthesisLoading: boolean
+  icon: LucideIcon
 }
 
 function ContainerNode({ data }: NodeProps<Node<ContainerData>>) {
@@ -165,7 +168,10 @@ function ContainerNode({ data }: NodeProps<Node<ContainerData>>) {
             {data.subtitle as string}
           </span>
         </div>
-        <BookOpen className="w-4 h-4 shrink-0 opacity-40" style={{ color: data.color as string }} />
+        {(() => {
+          const Icon = data.icon as LucideIcon
+          return <Icon className="w-4 h-4 shrink-0 opacity-40" style={{ color: data.color as string }} />
+        })()}
       </div>
 
       {/* Stale banner */}
@@ -490,6 +496,7 @@ function buildElements(
         synthesis: domainSynth?.synthesis || '',
         isStale: domainSynth?.is_stale ?? false,
         isSynthesisLoading: synthesisLoading === meta.domain,
+        icon: meta.icon,
       },
     })
 

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -127,7 +127,17 @@ function ContainerNode({ data }: NodeProps<Node<ContainerData>>) {
 
   return (
     <div
-      className="rounded-xl overflow-hidden transition-all duration-300 cursor-pointer"
+      role="button"
+      tabIndex={0}
+      aria-label={`Dominio ${data.label as string}, ${data.childCount as number} nodos`}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          e.stopPropagation()
+          ;(e.currentTarget as HTMLElement).click()
+        }
+      }}
+      className="rounded-xl overflow-hidden transition-all duration-300 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-500 focus-visible:outline-offset-2"
       style={{
         width: CONTAINER_WIDTH,
         height: CONTAINER_HEIGHT,
@@ -253,7 +263,11 @@ function OrbitalNode({ data }: NodeProps<Node<OrbitalData>>) {
       </NodeToolbar>
 
       <div
-        className="cursor-pointer rounded-full transition-all duration-150 hover:scale-110 flex items-center justify-center"
+        role="button"
+        tabIndex={0}
+        aria-label={`${data.label as string}, intensidad ${data.salience as number}/10`}
+        aria-pressed={isSelected}
+        className="cursor-pointer rounded-full transition-all duration-150 hover:scale-110 flex items-center justify-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-500 focus-visible:outline-offset-2"
         style={{
           width: size,
           height: size,
@@ -263,6 +277,13 @@ function OrbitalNode({ data }: NodeProps<Node<OrbitalData>>) {
             : `0 2px 8px ${color}40`,
         }}
         onClick={(e) => { e.stopPropagation(); data.onSelect(data.nodeId as number) }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.stopPropagation()
+            data.onSelect(data.nodeId as number)
+          }
+        }}
       >
         <span
           style={{

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useCallback, useEffect } from 'react'
 import {
   ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
   Background,
   Panel,
   useNodesState,
@@ -14,6 +16,7 @@ import {
   type NodeProps,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
+import { useReducedMotion } from 'framer-motion'
 import { BookOpen, RefreshCw } from 'lucide-react'
 import type { CharacterNode, CharacterNodeDomain, DomainSynthesis } from '@/services/api'
 
@@ -594,9 +597,11 @@ interface Props {
   onContextMenu?: (event: ContextMenuEvent) => void
   /** Persists orbital drag-stop position. Pass `moveNode` from useCharacterGraph. */
   onPersistPosition?: (id: number, x: number, y: number) => void
+  /** When the right-side drawer opens/closes, canvas refits to compensate. */
+  drawerOpen: boolean
 }
 
-export function CharacterGraphCanvas({
+function CharacterGraphCanvasInner({
   nodes: charNodes,
   selectedNodeId,
   synthesis,
@@ -605,6 +610,7 @@ export function CharacterGraphCanvas({
   onContainerClick,
   onContextMenu,
   onPersistPosition,
+  drawerOpen,
 }: Props) {
   const handleSelectNode = useCallback(
     (id: number) => onSelectNode(id === selectedNodeId ? null : id),
@@ -635,6 +641,20 @@ export function CharacterGraphCanvas({
     })
   }, [flowNodes, setNodes])
   useEffect(() => { setEdges(flowEdges) }, [flowEdges, setEdges])
+
+  const reactFlow = useReactFlow()
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    // Debounced slightly so it runs AFTER the drawer's transition starts occupying space.
+    const t = window.setTimeout(() => {
+      reactFlow.fitView({
+        padding: 0.12,
+        duration: prefersReducedMotion ? 0 : 250,
+      })
+    }, 120)
+    return () => window.clearTimeout(t)
+  }, [drawerOpen, reactFlow, prefersReducedMotion])
 
   const handlePaneClick = useCallback(() => onSelectNode(null), [onSelectNode])
 
@@ -769,5 +789,13 @@ export function CharacterGraphCanvas({
         </div>
       </Panel>
     </ReactFlow>
+  )
+}
+
+export function CharacterGraphCanvas(props: Props) {
+  return (
+    <ReactFlowProvider>
+      <CharacterGraphCanvasInner {...props} />
+    </ReactFlowProvider>
   )
 }

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -640,14 +640,20 @@ export function CharacterGraphCanvas({
 
   const handleNodeDragStop = useCallback(
     (_: React.MouseEvent, draggedNode: Node) => {
-      setNodes(nds => resolveCollisions(nds))
-      // Only persist orbital positions. Containers/pills are not user-positioned yet (Fase 2).
-      if (draggedNode.type === 'child' && draggedNode.id.startsWith('node-') && onPersistPosition) {
-        const nodeId = parseInt(draggedNode.id.slice(5), 10)
-        if (!Number.isNaN(nodeId)) {
-          onPersistPosition(nodeId, draggedNode.position.x, draggedNode.position.y)
+      setNodes(nds => {
+        const resolved = resolveCollisions(nds)
+        // Only persist orbital positions. Containers/pills are not user-positioned yet (Fase 2).
+        if (draggedNode.type === 'child' && draggedNode.id.startsWith('node-') && onPersistPosition) {
+          const nodeId = parseInt(draggedNode.id.slice(5), 10)
+          if (!Number.isNaN(nodeId)) {
+            const resolvedNode = resolved.find(n => n.id === draggedNode.id)
+            const pos = resolvedNode?.position ?? draggedNode.position
+            // Defer so the side effect runs after React commits this state update.
+            Promise.resolve().then(() => onPersistPosition(nodeId, pos.x, pos.y))
+          }
         }
-      }
+        return resolved
+      })
     },
     [setNodes, onPersistPosition],
   )

--- a/src/components/character-graph/CharacterGraphCanvas.tsx
+++ b/src/components/character-graph/CharacterGraphCanvas.tsx
@@ -4,6 +4,7 @@ import {
   ReactFlowProvider,
   useReactFlow,
   Background,
+  MiniMap,
   Panel,
   useNodesState,
   useEdgesState,
@@ -767,6 +768,17 @@ function CharacterGraphCanvasInner({
       className="bg-[hsl(40_20%_97%)]"
       proOptions={{ hideAttribution: true }}
     >
+      <MiniMap
+        position="bottom-right"
+        nodeColor={(n) => (n.data?.color as string | undefined) ?? '#c4b9ae'}
+        nodeStrokeWidth={0}
+        maskColor="rgba(120, 113, 108, 0.12)"
+        bgColor="hsl(40 20% 97%)"
+        pannable
+        zoomable
+        style={{ border: '1px solid #e7e0d8', borderRadius: 8 }}
+      />
+
       <Background color="#e8e0d4" gap={20} size={1} />
 
       <Panel position="top-right">

--- a/src/components/character-graph/CharacterGraphPage.tsx
+++ b/src/components/character-graph/CharacterGraphPage.tsx
@@ -24,7 +24,7 @@ export function CharacterGraphPage({ characterId, worldId, onDelete }: Props) {
     synthesis, synthesisLoading,
     soul, soulLoading,
     voiceExamples, premise, speechPattern, generatingExamples,
-    loadGraph, removeNode, editNode,
+    loadGraph, removeNode, editNode, moveNode,
     updateVoice, saveExamples, generateExamples, sendMessage, generateNodes, clearChat,
     toggleMode, setSelectedNodeId,
     addFromCatalog, addFromContextual, regenerateSynthesis,
@@ -216,6 +216,7 @@ export function CharacterGraphPage({ characterId, worldId, onDelete }: Props) {
                 onSelectNode={handleSelectNode}
                 onContainerClick={handleContainerClick}
                 onContextMenu={handleContextMenu}
+                onPersistPosition={moveNode}
               />
             </div>
 

--- a/src/components/character-graph/CharacterGraphPage.tsx
+++ b/src/components/character-graph/CharacterGraphPage.tsx
@@ -217,6 +217,7 @@ export function CharacterGraphPage({ characterId, worldId, onDelete }: Props) {
                 onContainerClick={handleContainerClick}
                 onContextMenu={handleContextMenu}
                 onPersistPosition={moveNode}
+                drawerOpen={selectedContainer !== null}
               />
             </div>
 

--- a/src/components/character-graph/CharacterGraphPage.tsx
+++ b/src/components/character-graph/CharacterGraphPage.tsx
@@ -5,7 +5,7 @@ import { VoiceBadge } from './VoiceBadge'
 import { useCharacterGraph } from './useCharacterGraph'
 import { CharacterGraphCanvas, type ContextMenuEvent } from './CharacterGraphCanvas'
 import { CharacterChatPanel } from './CharacterChatPanel'
-import { GraphMinimap } from './GraphMinimap'
+import { DecisionFlowOutline } from './DecisionFlowOutline'
 import { CatalogDrawer } from './CatalogDrawer'
 import { ContainerContextMenu, OrbitalContextMenu } from './CharacterContextMenu'
 import { AIGeneratingIndicator } from '@/components/world-creation/AIGeneratingIndicator'
@@ -344,7 +344,7 @@ export function CharacterGraphPage({ characterId, worldId, onDelete }: Props) {
                 )}
               </div>
               <div className="flex-1 overflow-hidden min-h-0">
-                <GraphMinimap
+                <DecisionFlowOutline
                   nodes={nodes}
                   selectedNodeId={selectedNodeId}
                   onSelectNode={(id) => setSelectedNodeId(id)}

--- a/src/components/character-graph/DecisionFlowOutline.tsx
+++ b/src/components/character-graph/DecisionFlowOutline.tsx
@@ -10,7 +10,7 @@ const DOMAIN_META: Record<string, { label: string; color: string; bg: string }> 
 }
 
 // Fixed order for pipeline display
-const PIPELINE_ORDER = ['origin', 'fear', 'drive', 'mask', 'bond']
+const PIPELINE_ORDER = ['origin', 'fear', 'drive', 'bond', 'mask']
 
 interface Props {
   nodes: CharacterNode[]

--- a/src/components/character-graph/DecisionFlowOutline.tsx
+++ b/src/components/character-graph/DecisionFlowOutline.tsx
@@ -19,7 +19,7 @@ interface Props {
   onRemoveNode?: (id: number) => void
 }
 
-export function GraphMinimap({ nodes, selectedNodeId, onSelectNode, onRemoveNode }: Props) {
+export function DecisionFlowOutline({ nodes, selectedNodeId, onSelectNode, onRemoveNode }: Props) {
   const nodeByDomain = new Map<string, CharacterNode[]>()
   for (const node of nodes) {
     const list = nodeByDomain.get(node.domain) || []

--- a/src/components/character-graph/edges/FloatingEdge.tsx
+++ b/src/components/character-graph/edges/FloatingEdge.tsx
@@ -1,0 +1,43 @@
+import { BaseEdge, getBezierPath, useInternalNode } from '@xyflow/react'
+import type { EdgeProps } from '@xyflow/react'
+import { getEdgeParams } from './getEdgeParams'
+
+/**
+ * Bezier edge anchored at the intersection of the source/target node bounding
+ * boxes. Use for orbital ↔ container edges so lines never pile onto a single
+ * handle point.
+ */
+export function FloatingEdge({
+  id,
+  source,
+  target,
+  markerEnd,
+  markerStart,
+  style,
+}: EdgeProps) {
+  const sourceNode = useInternalNode(source)
+  const targetNode = useInternalNode(target)
+
+  if (!sourceNode || !targetNode) return null
+
+  const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(sourceNode, targetNode)
+
+  const [edgePath] = getBezierPath({
+    sourceX: sx,
+    sourceY: sy,
+    sourcePosition: sourcePos,
+    targetPosition: targetPos,
+    targetX: tx,
+    targetY: ty,
+  })
+
+  return (
+    <BaseEdge
+      id={id}
+      path={edgePath}
+      markerEnd={markerEnd}
+      markerStart={markerStart}
+      style={style}
+    />
+  )
+}

--- a/src/components/character-graph/edges/LiteraryFlowEdge.tsx
+++ b/src/components/character-graph/edges/LiteraryFlowEdge.tsx
@@ -13,8 +13,8 @@ interface LiteraryFlowEdgeData extends Record<string, unknown> {
 /**
  * Custom edge for the 4 domain-chain edges (CREENCIAS → MIEDOS → … → MASCARAS).
  * - Path: smoothstep (preserves the existing vertical cascade).
- * - Label: rendered in the HTML layer via EdgeLabelRenderer so real Lora italic
- *   can be used (SVG <text> rendered the serif poorly).
+ * - Label: rendered in the HTML layer via EdgeLabelRenderer so the project's
+ *   serif display font can be used in italic (SVG <text> rendered it poorly).
  * - Ink-pool: small SVG circle at 20% of the path in the domain color.
  * - Particle: an animated circle gliding from source to target, reinforcing
  *   the "causation flows downward" metaphor. Respects prefers-reduced-motion.
@@ -88,7 +88,7 @@ export function LiteraryFlowEdge({
       {label && (
         <EdgeLabelRenderer>
           <div
-            className="absolute pointer-events-auto font-display italic text-[11px] leading-snug text-stone-500 bg-[hsl(40_20%_97%)]/90 px-2 py-0.5 rounded-sm"
+            className="absolute pointer-events-auto nodrag nopan font-display italic text-[11px] leading-snug text-stone-500 bg-[hsl(40_20%_97%)]/90 px-2 py-0.5 rounded-sm"
             style={{
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
             }}

--- a/src/components/character-graph/edges/LiteraryFlowEdge.tsx
+++ b/src/components/character-graph/edges/LiteraryFlowEdge.tsx
@@ -1,0 +1,102 @@
+import { BaseEdge, EdgeLabelRenderer, getSmoothStepPath } from '@xyflow/react'
+import type { EdgeProps } from '@xyflow/react'
+import { useReducedMotion } from 'framer-motion'
+
+interface LiteraryFlowEdgeData extends Record<string, unknown> {
+  label: string
+  /** Hex color of the source domain — drives ink-pool and particle color. */
+  domainColor: string
+  /** Index of this edge in the chain (0..3); staggers the particle animation. */
+  chainIndex: number
+}
+
+/**
+ * Custom edge for the 4 domain-chain edges (CREENCIAS → MIEDOS → … → MASCARAS).
+ * - Path: smoothstep (preserves the existing vertical cascade).
+ * - Label: rendered in the HTML layer via EdgeLabelRenderer so real Lora italic
+ *   can be used (SVG <text> rendered the serif poorly).
+ * - Ink-pool: small SVG circle at 20% of the path in the domain color.
+ * - Particle: an animated circle gliding from source to target, reinforcing
+ *   the "causation flows downward" metaphor. Respects prefers-reduced-motion.
+ */
+export function LiteraryFlowEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  style,
+  data,
+}: EdgeProps) {
+  const prefersReducedMotion = useReducedMotion()
+  const edgeData = (data ?? {}) as Partial<LiteraryFlowEdgeData>
+  const label = edgeData.label ?? ''
+  const domainColor = edgeData.domainColor ?? '#a8a29e'
+  const chainIndex = edgeData.chainIndex ?? 0
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  })
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+
+      {/* Ink-pool: static dot at 20% of the path so the label has a visual anchor. */}
+      <circle r={3} fill={domainColor}>
+        <animateMotion
+          dur="0.001s"
+          repeatCount="1"
+          fill="freeze"
+          keyPoints="0.2;0.2"
+          keyTimes="0;1"
+          path={edgePath}
+        />
+      </circle>
+
+      {/* Animated particle — or static dot if reduced-motion. */}
+      {prefersReducedMotion ? (
+        <circle r={3} fill={domainColor} opacity={0.7}>
+          <animateMotion
+            dur="0.001s"
+            repeatCount="1"
+            fill="freeze"
+            keyPoints="0.5;0.5"
+            keyTimes="0;1"
+            path={edgePath}
+          />
+        </circle>
+      ) : (
+        <circle r={3} fill={domainColor} opacity={0.85}>
+          <animateMotion
+            dur="4s"
+            repeatCount="indefinite"
+            path={edgePath}
+            begin={`${chainIndex}s`}
+          />
+        </circle>
+      )}
+
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            className="absolute pointer-events-auto font-display italic text-[11px] leading-snug text-stone-500 bg-[hsl(40_20%_97%)]/90 px-2 py-0.5 rounded-sm"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}

--- a/src/components/character-graph/edges/getEdgeParams.ts
+++ b/src/components/character-graph/edges/getEdgeParams.ts
@@ -1,0 +1,82 @@
+import { Position } from '@xyflow/react'
+import type { InternalNode, Node } from '@xyflow/react'
+
+/**
+ * Ported from React Flow's "Simple Floating Edges" example, adapted to v12:
+ *   - `node.internals.positionAbsolute` replaces v11's `nodeInternals.get().positionAbsolute`.
+ *   - `node.measured` supersedes `node.width/height`.
+ * The helper computes the intersection of the line connecting two node centers
+ * with each node's bounding box, so edges attach to the nearest side instead of
+ * a fixed handle.
+ */
+
+function getNodeIntersection(
+  intersectionNode: InternalNode<Node>,
+  targetNode: InternalNode<Node>,
+): { x: number; y: number } {
+  const iw = intersectionNode.measured?.width ?? 0
+  const ih = intersectionNode.measured?.height ?? 0
+  const tw = targetNode.measured?.width ?? 0
+  const th = targetNode.measured?.height ?? 0
+
+  const ipos = intersectionNode.internals.positionAbsolute
+  const tpos = targetNode.internals.positionAbsolute
+
+  const w = iw / 2
+  const h = ih / 2
+
+  const x2 = ipos.x + w
+  const y2 = ipos.y + h
+  const x1 = tpos.x + tw / 2
+  const y1 = tpos.y + th / 2
+
+  const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h)
+  const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h)
+  const a = 1 / (Math.abs(xx1) + Math.abs(yy1) || 1)
+  const xx3 = a * xx1
+  const yy3 = a * yy1
+  const x = w * (xx3 + yy3) + x2
+  const y = h * (yy3 - xx3) + y2
+
+  return { x, y }
+}
+
+function getEdgePosition(
+  node: InternalNode<Node>,
+  intersectionPoint: { x: number; y: number },
+): Position {
+  const nx = Math.round(node.internals.positionAbsolute.x)
+  const ny = Math.round(node.internals.positionAbsolute.y)
+  const nw = node.measured?.width ?? 0
+  const nh = node.measured?.height ?? 0
+  const px = Math.round(intersectionPoint.x)
+  const py = Math.round(intersectionPoint.y)
+
+  if (px <= nx + 1) return Position.Left
+  if (px >= nx + nw - 1) return Position.Right
+  if (py <= ny + 1) return Position.Top
+  if (py >= ny + nh - 1) return Position.Bottom
+  return Position.Top
+}
+
+export function getEdgeParams(
+  source: InternalNode<Node>,
+  target: InternalNode<Node>,
+): {
+  sx: number; sy: number
+  tx: number; ty: number
+  sourcePos: Position; targetPos: Position
+} {
+  const sourceIntersectionPoint = getNodeIntersection(source, target)
+  const targetIntersectionPoint = getNodeIntersection(target, source)
+  const sourcePos = getEdgePosition(source, sourceIntersectionPoint)
+  const targetPos = getEdgePosition(target, targetIntersectionPoint)
+  return {
+    sx: sourceIntersectionPoint.x,
+    sy: sourceIntersectionPoint.y,
+    tx: targetIntersectionPoint.x,
+    ty: targetIntersectionPoint.y,
+    sourcePos,
+    targetPos,
+  }
+}

--- a/src/components/character-graph/edges/index.ts
+++ b/src/components/character-graph/edges/index.ts
@@ -1,0 +1,3 @@
+export { FloatingEdge } from './FloatingEdge'
+export { LiteraryFlowEdge } from './LiteraryFlowEdge'
+export { getEdgeParams } from './getEdgeParams'


### PR DESCRIPTION
## Summary

Upgrade the character psychology graph canvas in two phases. **Fase 0** ships cleanup bugfixes; **Fase 1** reshapes the visual language of the canvas toward the project's literary aesthetic. Fase 2 (NodeResizer + Save/Restore + embossed containers) and Fase 3 (spine, breathing, torn-paper, intersection-drag, PNG export) are deferred to separate specs.

### Fase 0 — cleanup (5 tasks, 7 commits)
- Scope drag collisions to orbital children only — containers and entry/exit pills stay anchored.
- Persist orbital drag positions via the existing `moveNode` hook, using post-collision coordinates (deferred side effect).
- Drawer-aware `fitView`: split canvas into `<ReactFlowProvider>` wrapper + Inner, refit on drawer toggle with `prefers-reduced-motion` honored and stable `fitView` dep.
- Rename `GraphMinimap` → `DecisionFlowOutline` (it was a pipeline TOC, not a minimap). Also fixes a pre-existing `PIPELINE_ORDER` transposition (`mask`/`bond` were swapped).
- Keyboard + screen-reader affordances on `ContainerNode` and `OrbitalNode` (`role`, `tabIndex`, `aria-label`, `aria-pressed`, `onKeyDown` Enter/Space, `focus-visible` outline).

### Fase 1 — edges + warmth (8 tasks, 9 commits)
- `edges/getEdgeParams.ts`: v12 geometry helper using `useInternalNode`.
- `edges/FloatingEdge.tsx`: Bezier edge anchored at rect intersections. Orbital → container edges migrated to `type: 'floating'` — no more sunburst.
- `edges/LiteraryFlowEdge.tsx`: smoothstep path + `EdgeLabelRenderer` HTML label (Newsreader italic) + SVG ink-pool + `animateMotion` particle staggered across the 4 edges. Honors `prefers-reduced-motion`.
- Domain-chain edges migrated to `type: 'literaryFlow'`; dropped SVG label styling.
- Official `<MiniMap />` bottom-right, colored by domain.
- Per-domain glyphs (Sprout/Flame/Compass/Zap/VenetianMask) replace repeated `BookOpen`.
- Two-layer `<Background />` (Lines + Dots) and warmer canvas tint.

### Stats
- 19 commits (13 tasks + 4 fix commits from mid-flight reviews + 2 docs commits)
- 7 files changed in `src/components/character-graph/` (**+349 / −50**)
- 4 new files under `src/components/character-graph/edges/`
- 1 git rename (`GraphMinimap.tsx` → `DecisionFlowOutline.tsx`)
- Design spec at `docs/superpowers/specs/2026-04-16-character-graph-edges-warmth-design.md`
- Implementation plan at `docs/superpowers/plans/2026-04-16-character-graph-edges-warmth.md`

## Test Plan

No test framework in the repo; verification is manual in the browser. Open a character with ≥ 10 nodes across ≥ 3 domains:

- [ ] Drag an orbital near a container — container does NOT move (Fase 0.1).
- [ ] Click a container — drawer opens, canvas refits within ~250ms; close drawer — canvas refits back (Fase 0.3).
- [ ] Drag an orbital 200px, hard-refresh — position persists (Fase 0.2).
- [ ] Tab into canvas, press Tab again — focus ring appears on node; Enter selects orbital / opens catalog for container (Fase 0.5).
- [ ] Drag orbital above/below container midline — edge re-anchors to top/bottom, no sunburst (Fase 1.1–1.3).
- [ ] Zoom to 1.0 on a chain label — renders in Newsreader italic with background pill (Fase 1.4–1.5).
- [ ] 4 particles glide down the chain, staggered 1s; DevTools → reduced-motion → particles freeze at midpoint (Fase 1.4–1.5).
- [ ] Minimap bottom-right shows 5 colored containers + orbital dots; drag inside it pans, scroll zooms (Fase 1.7).
- [ ] Each container header has its distinct glyph (Fase 1.8).
- [ ] Background shows paper lines + dots over warm cream tint (Fase 1.9).

## Notes
- `npm run build` may report TS errors in `src/pages/home/WorldBiblePage.tsx` on `main` — those are unrelated to this feature and out of scope.
- `npm run lint` is clean (0 errors; 6 pre-existing warnings in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)